### PR TITLE
Metrics produce Nagios-style output if given non-metric args instead of ...

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,6 @@ require 'sensu-plugin/check/cli'
 
 class MyCheck < Sensu::Plugin::Check::CLI
 
-  check_name 'my_awesome_check' # defaults to class name
   option :foo, :short => '-f' # Mixlib::CLI is included
 
   def run
@@ -27,9 +26,9 @@ class MyCheck < Sensu::Plugin::Check::CLI
 end
 #+END_SRC
 
-This will output the string "my_awesome_check OK: All is well" (like a
-Nagios plugin), and exit with a code of 0. The available exit methods,
-which will immediately end the process, are:
+This will output the string "MyCheck OK: All is well" (like a Nagios
+plugin), and exit with a code of 0. The available exit methods, which
+will immediately end the process, are:
 
   - =ok=
   - =warning=

--- a/lib/sensu-plugin/check/cli.rb
+++ b/lib/sensu-plugin/check/cli.rb
@@ -5,22 +5,12 @@ module Sensu
     class Check
       class CLI < Sensu::Plugin::CLI
 
-        class << self
-          def check_name(name=nil)
-            if name
-              @check_name = name
-            else
-              @check_name || self.to_s
-            end
-          end
-        end
-
         def message(msg)
           @message = msg
         end
 
         def output(msg=@message)
-          puts "#{self.class.check_name} #{@status}" + (msg ? ": #{msg}" : "")
+          nagios_style_output(msg)
         end
 
       end

--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -15,6 +15,20 @@ module Sensu
         puts "Sensu::Plugin::CLI: #{args}"
       end
 
+      # Implementations of output can call this method to get a "Nagios
+      # style" line of text. Sensu plugins can output anything, but this
+      # is a familiar format and allows even using a sensu-plugin check
+      # from Nagios in a pinch.
+
+      def nagios_style_output(msg=nil)
+        name = ENV['SENSU_PLUGIN_NAME'] || self.class.name
+        if msg.nil?
+          puts "#{name} #{@status}"
+        else
+          puts "#{name} #{@status}: " + msg.to_s.gsub("\n", ' ')
+        end
+      end
+
       # This will define 'ok', 'warning', 'critical', and 'unknown'
       # methods, which the plugin should call to exit.
 

--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -8,17 +8,28 @@ module Sensu
 
         class JSON < Sensu::Plugin::CLI
           def output(obj=nil)
-            unless obj.nil? || obj.is_a?(String) || obj.is_a?(Exception)
+            if obj.respond_to? :[]
               obj['timestamp'] ||= Time.now.to_i
               puts ::JSON.generate(obj)
+            else
+              # `obj` does not correspond to a JSON object; it's probably
+              # a string or exception
+              nagios_style_output(obj)
             end
           end
         end
 
         class Graphite < Sensu::Plugin::CLI
           def output(path=nil, value=nil, timestamp=Time.now.to_i)
-            unless path.nil? || path.is_a?(Exception) || value.nil?
+            if path.is_a?(String) && value.is_a?(Numeric)
               puts [path, value, timestamp].join("\t")
+            elsif path.nil?
+              # Do nothing; this is a special case for plugins that
+              # output multiple metrics per run
+            else
+              # In this case, `path` is probably a misnomer, and we've
+              # been given a string or exception
+              nagios_style_output(path)
             end
           end
         end


### PR DESCRIPTION
...being silent; remove check_name
