### PR TITLE
Allow ARGV to be injected for improved testability

### DIFF
--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -8,9 +8,9 @@ module Sensu
 
       attr_accessor :argv
 
-      def initialize
-        super
-        self.argv = self.parse_options
+      def initialize(argv=ARGV)
+        super()
+        self.argv = self.parse_options(argv)
       end
 
       # Implementing classes should override this to produce appropriate


### PR DESCRIPTION
Currently ARGV is hardcoded into sensu plugins which makes any sort of automated testing harder to do. This pull request modifies the CLI class to accept ARGV in its constructor or falls back to using ARGV directly if it isn't passed in. From what I've seen of the community plugins repo it doesn't look like this change will conflict with anyones code. Is this something you'd be interested in?
