### PR TITLE
Add rescue for invalid options

### DIFF
--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -56,6 +56,8 @@ module Sensu
           check.run
         rescue SystemExit => e
           exit e.status
+        rescue OptionParser::InvalidOption => e
+          exit 1
         rescue Exception => e
           check.critical "Check failed to run: #{e.message}, #{e.backtrace}"
         end


### PR DESCRIPTION
adds rescue for invalid options passed to scripts on the cli. If this is not in place the call on check raises error which confuses the user and it's hard to discover what the actual problem is. I had some challenges testing this as I am not used to the code base ... and I assume there is a more intelligent way of accomplishing this.

To replicate basically add a script that has wrong parameter

"command": "some_check.rb --silly parameter"
