### PR TITLE
add more silence filter options

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -87,7 +87,7 @@ module Sensu
       stashes = {
         'client' => '/silence/' + @event['client']['name'],
         'check'  => '/silence/' + @event['client']['name'] + '/' + @event['check']['name'],
-        'all'           => '/silence/' + '*'
+        'all'    => '/silence/' + '*'
       }
       @event['client']['subscriptions'].each do |s|
         stashes.merge!({ "sub_#{s}" => "/silence/subscribed/#{s}" })

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -89,8 +89,10 @@ module Sensu
         'check'  => '/silence/' + @event['client']['name'] + '/' + @event['check']['name'],
         'all'    => '/silence/' + '*'
       }
-      @event['client']['subscriptions'].each do |s|
-        stashes.merge!({ "sub_#{s}" => "/silence/subscribed/#{s}" })
+      if @event['client']['subscriptions']
+        @event['client']['subscriptions'].each do |s|
+          stashes.merge!({ "sub_#{s}" => "/silence/subscribed/#{s}" })
+        end
       end
       stashes.each do |scope, path|
         begin

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -86,7 +86,8 @@ module Sensu
     def filter_silenced
       stashes = {
         'client' => '/silence/' + @event['client']['name'],
-        'check'  => '/silence/' + @event['client']['name'] + '/' + @event['check']['name']
+        'check'  => '/silence/' + @event['client']['name'] + '/' + @event['check']['name'],
+        'all'           => '/silence/' + '*'
       }
       stashes.each do |scope, path|
         begin

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -89,6 +89,9 @@ module Sensu
         'check'  => '/silence/' + @event['client']['name'] + '/' + @event['check']['name'],
         'all'           => '/silence/' + '*'
       }
+      @event['client']['subscriptions'].each do |s|
+        stashes.merge!({ "sub_#{s}" => "/silence/subscribed/#{s}" })
+      end
       stashes.each do |scope, path|
         begin
           timeout(2) do

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -90,8 +90,8 @@ module Sensu
         'all'    => '/silence/' + '*'
       }
       if @event['client']['subscriptions']
-        @event['client']['subscriptions'].each do |s|
-          stashes.merge!({ "sub_#{s}" => "/silence/subscribed/#{s}" })
+        @event['client']['subscriptions'].each do |subscription|
+          stashes.merge!({ "sub_#{subscription}" => "/silence/subscribed/#{subscription}" })
         end
       end
       stashes.each do |scope, path|

--- a/lib/sensu-plugin.rb
+++ b/lib/sensu-plugin.rb
@@ -1,6 +1,6 @@
 module Sensu
   module Plugin
-    VERSION = "0.1.7"
+    VERSION = "0.1.8"
     EXIT_CODES = {
       'OK'       => 0,
       'WARNING'  => 1,

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -22,7 +22,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
 
   def test_resolve_enough_occurrences
     event = {
-      'client' => { 'name' => 'test' },
+      'client' => { 'name' => 'test', 'subscriptions' => ["test"] },
       'check' => { 'name' => 'test', 'occurrences' => 2 },
       'occurrences' => 3
     }
@@ -33,7 +33,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
 
   def test_refresh_enough_occurrences
     event = {
-      'client' => { 'name' => 'test' },
+      'client' => { 'name' => 'test', 'subscriptions' => ["test"] },
       'check' => { 'name' => 'test' },
       'occurrences' => 60,
       'action' => 'create'
@@ -57,7 +57,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
 
   def test_refresh_bypass
     event = {
-      'client' => { 'name' => 'test' },
+      'client' => { 'name' => 'test', 'subscriptions' => ["test"] },
       'check' => { 'name' => 'test', 'refresh' => 0 },
       'occurrences' => 59,
       'action' => 'create'
@@ -69,7 +69,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
 
   def test_refresh_less_than_interval
     event = {
-      'client' => { 'name' => 'test' },
+      'client' => { 'name' => 'test', 'subscriptions' => ["test"] },
       'check' => { 'name' => 'test', 'refresh' => 30 },
       'occurrences' => 59,
       'action' => 'create'
@@ -92,7 +92,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
 
   def test_dependency_event_exists
     event = {
-      'client' => { 'name' => 'test' },
+      'client' => { 'name' => 'test', 'subscriptions' => ["test"] },
       'check' => { 'name' => 'test', 'dependencies' => ['foo', 'bar'] },
       'occurrences' => 1
     }


### PR DESCRIPTION
functionality I commonly use for silencing large groups of nodes during maintenance

- add ability to silence all with a stash of /silence/*
- add ability to silence a subscription group with /silence/subscribed/group_goes_here

thoughts?