### PR TITLE
add ability to silence entire check

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -85,8 +85,9 @@ module Sensu
 
     def filter_silenced
       stashes = {
-        'client' => '/silence/' + @event['client']['name'],
-        'check'  => '/silence/' + @event['client']['name'] + '/' + @event['check']['name']
+        'client'       => '/silence/' + @event['client']['name'],
+        'client_check' => '/silence/' + @event['client']['name'] + '/' + @event['check']['name'],
+        'check'        => '/silence/all/' + @event['check']['name']
       }
       stashes.each do |scope, path|
         begin


### PR DESCRIPTION
Silencing an entire check across clients can be pretty helpful. Overloading the /silence/ api endpoint this way is a little ... you know... but still. Rather than refactoring a ton of stuff, I'd like to see this happen.

Comments, suggestions, are always appreciated.
