### PR TITLE
Auto silence dependencies

### DIFF
--- a/README.org
+++ b/README.org
@@ -131,8 +131,8 @@ matching.
 
 The following example solves 2 types of problems:
 
-  - Silence events for virtual node **foo** when physical node **bar** is unreachable
-  - Silence events for **service_b** checks when **service_a** checks fail
+  - Silence events for node *foo* when node *bar* is unreachable
+  - Silence events for *service_b* checks when *service_a* checks fail
 
 On the Sensu server
 #+BEGIN_EXAMPLE
@@ -152,7 +152,7 @@ On the Sensu server
 }
 #+END_EXAMPLE
 
-On virtual host **foo** running on physical host **bar**
+On *foo*
 
 #+BEGIN_EXAMPLE
 {

--- a/README.org
+++ b/README.org
@@ -127,7 +127,9 @@ JSON file in =/etc/sensu/conf.d=, with a unique top-level key, like:
 Sensu checks already support dependencies. Now, the client can be configured to
 depend on events associated with other clients. Furthermore, it is now possible
 for handlers using this code to auto-silence events based on dependency
-matching.
+matching. By auto-silencing dependencies, we're positioning ourselves to
+refactor sensu-dashboard to hide silent events (this work has not been done yet
+but is planned).
 
 The following example solves 2 types of problems:
 

--- a/README.org
+++ b/README.org
@@ -133,22 +133,22 @@ but is planned).
 
 The following example solves 2 types of problems:
 
-  - Silence events for node *foo* when node *bar* is unreachable
-  - Silence events for *service_b* checks when *service_a* checks fail
+  - Silence all events for node *foo* when node *bar* is unreachable
+  - Silence *check_2* events when *check_1* fails
 
 On the Sensu server
 #+BEGIN_EXAMPLE
 {
   "auto_silence_dependencies": true
   "checks": {
-    "service_a": {
+    "check_1": {
       "command": "exit 2"
       "subscribers": ["all"],
     },
-    "service_b": {
+    "check_2": {
       "command": "exit 2"
       "subscribers": ["all"],
-      "dependencies" ["service_a"]
+      "dependencies" ["check_1"]
     }
   }
 }

--- a/README.org
+++ b/README.org
@@ -154,7 +154,7 @@ On the Sensu server
 }
 #+END_EXAMPLE
 
-On *foo*
+On foo client
 
 #+BEGIN_EXAMPLE
 {

--- a/README.org
+++ b/README.org
@@ -122,6 +122,56 @@ JSON file in =/etc/sensu/conf.d=, with a unique top-level key, like:
 }
 #+END_EXAMPLE
 
+** Dependencies
+
+Sensu checks already support dependencies. Now, the client can be configured to
+depend on events associated with other clients. Furthermore, it is now possible
+for handlers using this code to auto-silence events based on dependency
+matching.
+
+The following example solves 2 types of problems:
+
+  - Silence events for virtual node **foo** when physical node **bar** is unreachable
+  - Silence events for **service_b** checks when **service_a** checks fail
+
+On the Sensu server
+#+BEGIN_EXAMPLE
+{
+  "auto_silence_dependencies": true
+  "checks": {
+    "service_a": {
+      "command": "exit 2"
+      "subscribers": ["all"],
+    },
+    "service_b": {
+      "command": "exit 2"
+      "subscribers": ["all"],
+      "dependencies" ["service_a"]
+    }
+  }
+}
+#+END_EXAMPLE
+
+On virtual host **foo** running on physical host **bar**
+
+#+BEGIN_EXAMPLE
+{
+  "client": {
+    "name": "foo",
+    "address": "192.168.0.2",
+    "subscriptions": [
+      "all"
+    ],
+    "dependencies": {
+      "bar": [
+        "keepalive"
+      ]
+    }
+  }
+}
+#+END_EXAMPLE
+
+
 * License
 
 Copyright 2011 Decklin Foster

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -133,6 +133,17 @@ module Sensu
           end
         end
       end if @event['client']['dependencies']
+
+      @event['check']['dependencies'].each do |check|
+        if event_exists?(@event['client']['name'], check)
+          if settings['auto_silence_dependencies']
+            unless stash_exists? "%s/%s" % [@event['client']['name'], check]
+              http_post "/stashes/silence/%s/%s" % [@event['client']['name'], check]
+            end
+          end
+          bail "dependency event exists: %s" % check
+        end
+      end if @event['check']['dependencies']
     end
 
   end


### PR DESCRIPTION
This is my attempt to broaden the possible use case for dependencies. Event dependencies can now be matched across clients and every match can be auto-silenced (using stashes). This puts us in an excellent position to extend dashboard with a "hide silenced" toggle. Please see README.org for the newly added examples.