### PR TITLE
Adding method to disable autorun behavior.

### DIFF
--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -41,6 +41,11 @@ module Sensu
       # define two plugins in one script, the last one will 'win' in
       # terms of what gets auto-run.
 
+      # Disable run-on-exit behavior. For testing, etc
+      def self.disable_autorun
+        @@autorun = false
+      end
+
       @@autorun = self
       class << self
         def method_added(name)
@@ -51,15 +56,17 @@ module Sensu
       end
 
       at_exit do
-        begin
-          check = @@autorun.new
-          check.run
-        rescue SystemExit => e
-          exit e.status
-        rescue Exception => e
-          check.critical "Check failed to run: #{e.message}, #{e.backtrace}"
+        if autorun
+          begin
+            check = @@autorun.new
+            check.run
+          rescue SystemExit => e
+            exit e.status
+          rescue Exception => e
+            check.critical "Check failed to run: #{e.message}, #{e.backtrace}"
+          end
+          check.warning "Check did not exit! You should call an exit code method."
         end
-        check.warning "Check did not exit! You should call an exit code method."
       end
 
     end


### PR DESCRIPTION
This adds a method which will set the `@@autorun` class variable to `false`, as well as a check that will prevent the autorun behavior if the `@@autorun` variable evaluates to false.

This enables code-level tests, which are important because most checks interact with external resources (shelling out, accessing HTTP, etc) and are best tested with mocks/stubs.  Checks are getting more complex, and multiple authors are editing individual checks, so testing is becoming more important for checks.
