### PR TITLE
Add mixlib-cli and option parsing

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -1,11 +1,20 @@
 require 'net/http'
 require 'json'
 require 'sensu-plugin/utils'
+require 'mixlib/cli'
 
 module Sensu
 
   class Handler
     include Sensu::Plugin::Utils
+    include Mixlib::CLI
+
+    attr_accessor :argv
+
+    def initialize(argv = ARGV)
+      super()
+      self.argv = parse_options(argv)
+    end
 
     # Implementing classes should override this.
 


### PR DESCRIPTION
Added mixlib-cli (as used for checks via sensu-plugins) to allow command-line option parsing in handlers.

Some explanation:

While the json config should be used for most configuration, this requires 'hard-coding' a config 'section name' into the handler - usually the name of the handler, so it knows where to read it's config from.

For handlers which would be well suited to being run repeatedly with different configurations (such as mailer, where addressing different recipients for different events is useful), this could be used to specify to the handler on the command-line which config section to read from the json.

Assuming this patch is accepted, I have modified xmpp and mailer to use this functionality, and will submit more pull requests later.
