### PR TITLE
Allow dependencies to specify the client running the check

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -110,9 +110,16 @@ module Sensu
       if @event['check'].has_key?('dependencies')
         if @event['check']['dependencies'].is_a?(Array)
           @event['check']['dependencies'].each do |check|
+	    client = @event['client']['name']
+	    checklist = check.split('/')
+	    if checklist[1]
+	      client = checklist[0]
+	      check = checklist[1]
+	    end
+
             begin
               timeout(2) do
-                if event_exists?(@event['client']['name'], check)
+                if event_exists?(client, check)
                   bail 'check dependency event exists'
                 end
               end


### PR DESCRIPTION
A simple change to the format of dependencies entries, allowing checks to be prefixed by 'client'/ so that checks on one client can be depdendent on the results of checks on another e.g:

```
{
  "checks": {
    "banner": {
      "command": "/etc/sensu/plugins/network/check-banner.rb",
      "dependencies": ["foo.example.com/keepalive"]
    }
  }
}
```

I'm not sure if '/' is the best separator to use, or even if there isn't a better way to split the check field to extract the client, but this can be considered a 'proof of concept' if nothing else.
