### PR TITLE
Make it possible to disable the autorun class.

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -44,7 +44,7 @@ module Sensu
     end
 
     def self.disable_autorun
-      @@autorun = nil
+      @@autorun = false
     end
 
     at_exit do


### PR DESCRIPTION
I want to write unit tests for my handlers, and so the autorun kicking off is highly
inconvienient. Make it so that this can be optionally disabled by requiring a handler
and then calling HandlerClass.disable_autorun
