### PR TITLE
Improving handler debugging UX

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -36,7 +36,11 @@ module Sensu
 
     at_exit do
       handler = @@autorun.new
-      handler.read_event(STDIN)
+      event_string = handler.read_stdin
+      if event_string.nil?
+        print "You must pipe in data! URL FOR DOCS"
+      end
+      handler.read_event(event_string)
       handler.filter
       handler.handle
     end

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -33,7 +33,7 @@ module Sensu
 
       def read_event(input)
         begin
-          @event = ::JSON.parse(file.respond?(:read) ? input.read : input)
+          @event = ::JSON.parse(input.respond?(:read) ? input.read : input)
           @event['occurrences'] ||= 1
           @event['check']       ||= Hash.new
           @event['client']      ||= Hash.new

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -18,9 +18,22 @@ module Sensu
         @settings ||= config_files.map {|f| load_config(f) }.reduce {|a, b| a.deep_merge(b) }
       end
 
-      def read_event(file)
+      def read_stdin
+        stdin_string = ''
         begin
-          @event = ::JSON.parse(file.read)
+          while nextbytes = STDIN.read_nonblock(4096)
+            stdin_string += nextbytes
+          end
+        rescue EOFError => e
+          return stdin_string
+        rescue Errno::EWOULDBLOCK => e
+          return nil
+        end
+      end
+
+      def read_event(input)
+        begin
+          @event = ::JSON.parse(file.respond?(:read) ? input.read : input)
           @event['occurrences'] ||= 1
           @event['check']       ||= Hash.new
           @event['client']      ||= Hash.new


### PR DESCRIPTION
This has come up on the message list a few times.  This is more of a concept than a real PR ATM.  The idea is to catch handlers run with no STDIN, and print out a message pointing them to the doc page for debugging handlers.

I'm operating under the assumption that we don't want to change the Utils methods so this change to `read_event` is backwards compatible with IO object (even though I think it is only called with STDIN, at least in this codebase)

Thoughts?