### PR TITLE
Improve the UX for handler debugging by validating handler configs.

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -37,6 +37,7 @@ module Sensu
     at_exit do
       handler = @@autorun.new
       handler.read_event(STDIN)
+      settings(true) # Validate settings
       handler.filter
       handler.handle
     end

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -10,12 +10,15 @@ module Sensu
         end
       end
 
-      def load_config(filename)
-        JSON.parse(File.open(filename, 'r').read) rescue Hash.new
+      def load_config(filename, strict=false)
+        JSON.parse(File.open(filename, 'r').read)
+      rescue Errno::ENOENT => e
+        raise "Error reading JSON from #{filename}" if strict
+        Hash.new
       end
 
-      def settings
-        @settings ||= config_files.map {|f| load_config(f) }.reduce {|a, b| a.deep_merge(b) }
+      def settings(strict)
+        @settings ||= config_files.map {|f| load_config(f, strict) }.reduce {|a, b| a.deep_merge(b) }
       end
 
       def read_event(file)


### PR DESCRIPTION
Another handler UX idea.

This fail-fast approach should save folks some time debugging handler issues.  This is, however, backwards-incompatible, as some bogus, unrelated bad config file could break all handlers.

Another idea would be to only validate the config if the `handle` method raises and exception.  That way, it would be specific to the handlers (not global for all handlers, so it wouldn't break as described above).  It's definitely not as pretty in code, but it could give some nice feedback to users and make debugging quite easy.

Thinking about it more, I like the idea of catching exceptions from `handle` and then validating the settings, printing a message, and re-raising.

Thoughts?
