### PR TITLE
load check settings via ENV

### DIFF
--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -1,5 +1,6 @@
 require 'sensu-plugin'
 require 'mixlib/cli'
+require 'json'
 
 module Sensu
   module Plugin
@@ -11,6 +12,10 @@ module Sensu
       def initialize(argv=ARGV)
         super()
         self.argv = self.parse_options(argv)
+      end
+
+      def settings
+        @settings ||= JSON.load(ENV["SENSU_CHECK_SETTINGS"])
       end
 
       # Implementing classes should override this to produce appropriate

--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -1,4 +1,5 @@
 require 'sensu-plugin'
+require 'sensu-plugin/utils'
 require 'mixlib/cli'
 require 'json'
 
@@ -6,16 +7,22 @@ module Sensu
   module Plugin
     class CLI
       include Mixlib::CLI
+      include Sensu::Plugin::Utils
 
       attr_accessor :argv
 
       def initialize(argv=ARGV)
         super()
         self.argv = self.parse_options(argv)
+        config.merge!(check_settings.symbolize_keys!) {|key, v1, v2| v1 }
       end
 
-      def settings
-        @settings ||= JSON.load(ENV["SENSU_CHECK_SETTINGS"])
+      def check_name
+        ENV["SENSU_CHECK_NAME"]
+      end
+
+      def check_settings
+        @check_settings ||= settings["checks"] ? settings["checks"][check_name] : {}
       end
 
       # Implementing classes should override this to produce appropriate

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -61,4 +61,8 @@ class Hash
     end
     merge(other_hash, &merger)
   end
+
+  def symbolize_keys!
+    Hash[self.map{|(k,v)| [k.to_sym,v]}]
+  end
 end

--- a/test/external/check-options
+++ b/test/external/check-options
@@ -10,6 +10,7 @@ class TestCheck < Sensu::Plugin::Check::CLI
   option :unknown, :short => '-u'
   option :fail, :short => '-f'
   option :override, :short => '-O'
+  option :settings, :short => '-s'
 
   def run
     message "Testing, argv = #{argv.join(' ')}"
@@ -25,6 +26,8 @@ class TestCheck < Sensu::Plugin::Check::CLI
       raise RuntimeError
     elsif config[:override]
       ok "Overriding message"
+    elsif config[:settings]
+      ok settings.inspect
     end
   end
 

--- a/test/external/check-options
+++ b/test/external/check-options
@@ -27,8 +27,7 @@ class TestCheck < Sensu::Plugin::Check::CLI
     elsif config[:override]
       ok "Overriding message"
     elsif config[:settings]
-      ok settings.inspect
+      ok config.inspect
     end
   end
-
 end

--- a/test/external/config.json
+++ b/test/external/config.json
@@ -1,0 +1,7 @@
+{
+  "checks": {
+    "test1": {
+      "custom_value": "custom_key"
+    }
+  }
+}

--- a/test/external_check_test.rb
+++ b/test/external_check_test.rb
@@ -33,6 +33,13 @@ class TestCheckExternal < MiniTest::Unit::TestCase
     assert $?.exitstatus == 0 && !output.include?('argv =')
   end
 
+  def test_settings_env
+    settings = [ "foobar" ]
+    ENV["SENSU_CHECK_SETTINGS"] = JSON.generate(settings)
+    output = run_script '-s'
+    assert $?.exitstatus == 0 && output.include?(settings.first)
+  end
+
   def test_fallthrough
     run_script
     assert $?.exitstatus == 1

--- a/test/external_check_test.rb
+++ b/test/external_check_test.rb
@@ -33,11 +33,11 @@ class TestCheckExternal < MiniTest::Unit::TestCase
     assert $?.exitstatus == 0 && !output.include?('argv =')
   end
 
-  def test_settings_env
-    settings = [ "foobar" ]
-    ENV["SENSU_CHECK_SETTINGS"] = JSON.generate(settings)
+  def test_config_from_settings
+    ENV["SENSU_CHECK_NAME"] = "test1"
+    ENV["SENSU_CONFIG_FILES"] = "test/external/config.json"
     output = run_script '-s'
-    assert $?.exitstatus == 0 && output.include?(settings.first)
+    assert $?.exitstatus == 0 && output.include?("custom_value")
   end
 
   def test_fallthrough


### PR DESCRIPTION
So I had this idea that it would be nice to access the check's custom key/values (and maybe other stuff) from within the check plugin. Right now only handlers get access to the data, but it could be used in the checks themselves for configuration or other behavior changes in addition to command line options.

Not sure about naming it "settings". Might be confusing with the existing "config" used for command line options. Any other ideas for a name?

In addition to this PR, it requires a 1 line change for sensu-client to set the ENV before running the check. The only downside is an additional Oj.dump for each check execution. If that's a problem there could be a flag to turn it off.
