### PR TITLE
Allow arrays of JSON metrics to be output

### DIFF
--- a/lib/sensu-plugin.rb
+++ b/lib/sensu-plugin.rb
@@ -1,6 +1,6 @@
 module Sensu
   module Plugin
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
     EXIT_CODES = {
       'OK'       => 0,
       'WARNING'  => 1,

--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -13,6 +13,11 @@ module Sensu
             elsif obj.is_a?(Hash)
               obj['timestamp'] ||= Time.now.to_i
               puts ::JSON.generate(obj)
+            elsif obj.is_a?(Array)
+              obj.each do |h|
+                h['timestamp'] ||= Time.now.to_i if h.is_a?(Hash)
+              end
+              puts ::JSON.generate(obj)
             end
           end
         end

--- a/test/external/multi-json-output
+++ b/test/external/multi-json-output
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require 'sensu-plugin/metric/cli'
+
+class TestMetric < Sensu::Plugin::Metric::CLI::JSON
+
+  def run
+    metrics = [
+      { 'test' => 1 },
+      { 'test2' => 1 }
+    ]
+    ok metrics
+  end
+
+end

--- a/test/external_metric_test.rb
+++ b/test/external_metric_test.rb
@@ -15,6 +15,20 @@ class TestMetricExternal < MiniTest::Unit::TestCase
 
 end
 
+class TestJsonArrayMetricExternal < MiniTest::Unit::TestCase
+  include SensuPluginTestHelper
+
+  def setup
+    set_script 'external/multi-json-output'
+  end
+
+  def test_multi_json
+    output = JSON.parse(run_script)
+    assert $?.exitstatus == 0 && output.all? { |metric| metric.has_key?('timestamp') }
+  end
+
+end
+
 class TestGraphiteMetricExternal < MiniTest::Unit::TestCase
   include SensuPluginTestHelper
 


### PR DESCRIPTION
Add support for emitting a readable JSON blob when using Sensu::Plugin::Metric::CLI::JSON instead of new-line separated JSON hashes.

This is admittedly a terrible hack, but it was the least offensive solution I could come up with to an issue that actually affects me... without completely rewriting things, breaking backward compatibility, etc.