### PR TITLE
Update cli.rb

### DIFF
--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -23,7 +23,7 @@ module Sensu
               puts args[0].to_s
             else
               args[2] ||= Time.now.to_i
-              puts args[0..2].join("\t")
+              puts args[0..2].join(" ")
             end
           end
         end


### PR DESCRIPTION
space separate graphite metric components to match spec in http://graphite.readthedocs.org/en/latest/feeding-carbon.html and avoid breaking other metric handlers such as https://github.com/grobian/carbon-c-relay and InfluxDB
