### PR TITLE
Make bail safe for non-string inputs and uninitialized events

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -71,7 +71,9 @@ module Sensu
     end
 
     def bail(msg)
-      puts msg + ': ' + @event['client']['name'] + '/' + @event['check']['name']
+      client_name = @event['client']['name'] || 'error:no-client-name'
+      check_name = @event['check']['name'] || 'error:no-check-name'
+      puts "#{msg}: #{client_name}/#{check_name}"
       exit 0
     end
 


### PR DESCRIPTION
It was possible to bail on certain events before the 'client' and/or
'check' properties are initialized. In those cases you get a
stacktrace (over multiple lines) instead of the initial error message.

With this change you always get the error message that the handler sent.