### PR TITLE
More accurate refresh interval on first resend

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -110,7 +110,7 @@ module Sensu
       end
       if @event['occurrences'] > occurrences && @event['action'] == 'create'
         number = refresh.fdiv(interval).to_i
-        unless number == 0 || @event['occurrences'] % number == 0
+        unless number == 0 || (@event['occurrences'] - occurrences) % number == 0
           bail 'only handling every ' + number.to_s + ' occurrences'
         end
       end

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -59,7 +59,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test' },
-      'occurrences' => 63,
+      'occurrences' => 61,
       'action' => 'create'
     }
     output = run_script_with_input(JSON.generate(event))
@@ -71,7 +71,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test' },
-      'occurrences' => 59,
+      'occurrences' => 60,
       'action' => 'create'
     }
     output = run_script_with_input(JSON.generate(event))
@@ -83,7 +83,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test', 'refresh' => 0 },
-      'occurrences' => 59,
+      'occurrences' => 60,
       'action' => 'create'
     }
     output = run_script_with_input(JSON.generate(event))
@@ -95,7 +95,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test', 'refresh' => 30 },
-      'occurrences' => 59,
+      'occurrences' => 60,
       'action' => 'create'
     }
     output = run_script_with_input(JSON.generate(event))

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -59,7 +59,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test' },
-      'occurrences' => 60,
+      'occurrences' => 63,
       'action' => 'create'
     }
     output = run_script_with_input(JSON.generate(event))


### PR DESCRIPTION
Say I have a check where interval = 120, occurrences = 14, refresh = 1800 (the default). That means "number" is 1800.fdiv(120).to_i, which is 15.

At 14 occurrences, an alert is sent out.
At 15 occurrences, 15 % 15 is 0... so another alert is sent out.

In the PR, I subtract the occurrences threshold first before comparing to the refresh:
At 14 occurrences, an alert is sent out.
At 15 occurrences, (15 - 14) % 15 = 1. No alert is sent.
At 29 occurrences, (29 - 14) % 15 = 0. Another alert is sent, 30 minutes after the original, as was probably intended by the user.

This seems more in line with the idea of the refresh interval to me.