### PR TITLE
Handle Errno::ECONNREFUSED.

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -133,6 +133,8 @@ module Sensu
               bail scope + ' alerts silenced'
             end
           end
+        rescue Errno::ECONNREFUSED
+          puts 'connection refused attempting to query the sensu api for a stash'
         rescue Timeout::Error
           puts 'timed out while attempting to query the sensu api for a stash'
         end
@@ -154,6 +156,8 @@ module Sensu
                   bail 'check dependency event exists'
                 end
               end
+            rescue Errno::ECONNREFUSED
+              puts 'connection refused attempting to query the sensu api for an event'
             rescue Timeout::Error
               puts 'timed out while attempting to query the sensu api for an event'
             end


### PR DESCRIPTION
Added rescue statements for Errno::ECONNREFUSED around stash_exists? and
event_exists?. If Sensu API is unavailable then without these a plugin
handler will abort before calling the run() method and prevent full
handling of events.

In this situation with the sensu-api down, events should still continue to
be handled but without filtering on dependencies or stashes (i.e. you'll
get a few more, but at least you'll get something).