### PR TITLE
Allow users to have json_pure, json-ruby or json installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'json', :require => false

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -1,7 +1,23 @@
 require 'net/http'
-require 'json'
 require 'sensu-plugin/utils'
 require 'mixlib/cli'
+
+begin
+  # Attempt to load the json.rb file if available
+  require 'json'
+rescue LoadError
+  # Look for a json ruby gem
+  require 'rubygems'
+  begin
+    require 'json_pure'
+  rescue LoadError
+    begin
+      require 'json-ruby'
+    rescue LoadError
+      require 'json'
+    end
+  end
+end
 
 module Sensu
 

--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -1,5 +1,21 @@
 require 'sensu-plugin/cli'
-require 'json'
+begin
+  # Attempt to load the json.rb file if available
+  require 'json'
+rescue LoadError
+  # Look for a json ruby gem
+  require 'rubygems'
+  begin
+    require 'json_pure'
+  rescue LoadError
+    begin
+      require 'json-ruby'
+    rescue LoadError
+      require 'json'
+    end
+  end
+end
+
 
 module Sensu
   module Plugin

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*.rb']
   s.test_files    = Dir['test/*.rb']
 
-  s.add_dependency('json')
   s.add_dependency('mixlib-cli', '>= 1.1.0')
 
   s.add_development_dependency('rake')

--- a/test/external_handler_argument_test.rb
+++ b/test/external_handler_argument_test.rb
@@ -1,6 +1,21 @@
 require 'rubygems'
 require 'minitest/autorun'
-require 'json'
+begin
+  # Attempt to load the json.rb file if available
+  require 'json'
+rescue LoadError
+  # Look for a json ruby gem
+  require 'rubygems'
+  begin
+    require 'json_pure'
+  rescue LoadError
+    begin
+      require 'json-ruby'
+    rescue LoadError
+      require 'json'
+    end
+  end
+end
 
 class TestHandlerArgumentExternal < MiniTest::Unit::TestCase
   include SensuPluginTestHelper

--- a/test/external_handler_test.rb
+++ b/test/external_handler_test.rb
@@ -1,5 +1,20 @@
 require 'test_helper'
-require 'json'
+begin
+  # Attempt to load the json.rb file if available
+  require 'json'
+rescue LoadError
+  # Look for a json ruby gem
+  require 'rubygems'
+  begin
+    require 'json_pure'
+  rescue LoadError
+    begin
+      require 'json-ruby'
+    rescue LoadError
+      require 'json'
+    end
+  end
+end
 
 class TestHandlerExternal < MiniTest::Unit::TestCase
   include SensuPluginTestHelper


### PR DESCRIPTION
The JSON gem requires native compilation which isnt always viable for live servers. This change
allows users to optionally include json as a preference, but can use json_pure (for example) as an alternative.