### PR TITLE
Raise exception when trying to use sensu-handler without api.json file

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -76,6 +76,9 @@ module Sensu
     end
 
     def api_request(method, path, &blk)
+      if not settings.has_key?('api')
+        raise "api.json settings not found."
+      end
       http = Net::HTTP.new(settings['api']['host'], settings['api']['port'])
       req = net_http_req_class(method).new(path)
       if settings['api']['user'] && settings['api']['password']


### PR DESCRIPTION
Hi,

For someone new to ruby - the current error when the key is undefined is hard to decipher.
Since not running api could be common, I suggest it be checked and a better exception should be raised.