### PR TITLE
Consider state change just before a resolve event

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -108,7 +108,19 @@ module Sensu
       occurrences = (@event['check']['occurrences'] || defaults['occurrences']).to_i
       interval = (@event['check']['interval'] || defaults['interval']).to_i
       refresh = (@event['check']['refresh'] || defaults['refresh']).to_i
-      if @event['occurrences'] < occurrences
+
+      if @event['occurrences'] > occurrences && @event['action'] == 'resolve'
+        critical_occurrences, warning_occurrences = 0 ,0
+        @event['check']['history'][0...-1].each do |e|
+          critical_occurrences = critical_occurrences + 1 if e.to_i == 2
+          warning_occurrences = warning_occurrences + 1 if e.to_i == 1
+          break if e.to_i == 0
+        end
+        unless  critical_occurrences >  @event['occurrences'] || warning_occurrences >  @event['occurrences']
+          bail 'not enough occurrences'
+        end
+      end
+      if @event['occurrences'] < occurrences && @event['action'] == 'create'
         bail 'not enough occurrences'
       end
       if @event['occurrences'] > occurrences && @event['action'] == 'create'

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -33,10 +33,10 @@ class TestFilterExternal < MiniTest::Unit::TestCase
 
   def test_resolve_not_enough_occurrences
     event = {
-      'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
-      'occurrences' => 1,
-      'action' => 'resolve'
+        'client' => { 'name' => 'test' },
+        'check' => { 'name' => 'test', 'occurrences' => 3, 'history' => %w[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 2 1 1 1 0]},
+        'occurrences' => 10,
+        'action' => 'resolve'
     }
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
@@ -46,13 +46,37 @@ class TestFilterExternal < MiniTest::Unit::TestCase
   def test_resolve_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => { 'name' => 'test', 'occurrences' => 2, 'history' => %w[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 0]},
       'occurrences' => 2,
       'action' => 'resolve'
     }
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^Event:/, output)
+  end
+
+  def test_state_changed_resolve_enough_occurrences
+    event = {
+        'client' => { 'name' => 'test' },
+        'check' => { 'name' => 'test', 'occurrences' => 3, 'history' => %w[2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 1 1 1 0]},
+        'occurrences' => 10,
+        'action' => 'resolve'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/^Event:/, output)
+  end
+
+  def test_state_changed_resolve_not_enough_occurrences
+    event = {
+        'client' => { 'name' => 'test' },
+        'check' => { 'name' => 'test', 'occurrences' => 6, 'history' => %w[0 0 0 0 0 0 0 0 2 2 2 2 2 2 1 1 1 1 1 1 0]},
+        'occurrences' => 10,
+        'action' => 'resolve'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/^not enough occurrences/, output)
   end
 
   def test_refresh_enough_occurrences


### PR DESCRIPTION
When a check changes state just before a resolve event, its previous state's occurrences must be taken into account when filtering the event. 

Example: When history is [2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 1 1 1 0] and event['occurrences'] is configured to 10, this event would get filtered out because event['check']['occurrences'] = 3.