### PR TITLE
handle status histories like 1,1,1,1,1,1,1,2,0

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -97,7 +97,6 @@ module Sensu
     def filter_repeated
       defaults = {
         'occurrences' => 1,
-        'nonzero_occurrences' => 1,
         'interval' => 30,
         'refresh' => 1800
       }
@@ -107,11 +106,16 @@ module Sensu
       end
 
       occurrences = (@event['check']['occurrences'] || defaults['occurrences']).to_i
-      nonzero_occurrences = (@event['check']['nonzero_occurrences'] || defaults['nonzero_occurrences']).to_i
 
       interval = (@event['check']['interval'] || defaults['interval']).to_i
       refresh = (@event['check']['refresh'] || defaults['refresh']).to_i
-      if @event['nonzero_occurrences'] < nonzero_occurrences
+
+      history_s = @event['check']['history'].join("_")
+      if history_s =~/([1-9]+[0-9]*_)\1{#{occurrences-1}}([1-9]+[0-9]*_)\2{0,#{occurrences-2}}0$/
+        @event['occurrences'] = occurrences
+      end
+
+      if @event['occurrences'] < occurrences
         bail 'not enough occurrences'
       end
       if @event['occurrences'] > occurrences && @event['action'] == 'create'

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -97,6 +97,7 @@ module Sensu
     def filter_repeated
       defaults = {
         'occurrences' => 1,
+        'nonzero_occurrences' => 1,
         'interval' => 30,
         'refresh' => 1800
       }
@@ -106,9 +107,11 @@ module Sensu
       end
 
       occurrences = (@event['check']['occurrences'] || defaults['occurrences']).to_i
+      nonzero_occurrences = (@event['check']['nonzero_occurrences'] || defaults['nonzero_occurrences']).to_i
+
       interval = (@event['check']['interval'] || defaults['interval']).to_i
       refresh = (@event['check']['refresh'] || defaults['refresh']).to_i
-      if @event['occurrences'] < occurrences
+      if @event['nonzero_occurrences'] < nonzero_occurrences
         bail 'not enough occurrences'
       end
       if @event['occurrences'] > occurrences && @event['action'] == 'create'

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -24,7 +24,6 @@ module Sensu
         begin
           @event = ::JSON.parse(file.read)
           @event['occurrences'] ||= 1
-          @event['nonzero_occurrences'] ||= 1
           @event['check']       ||= Hash.new
           @event['client']      ||= Hash.new
         rescue => e

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -24,6 +24,7 @@ module Sensu
         begin
           @event = ::JSON.parse(file.read)
           @event['occurrences'] ||= 1
+          @event['nonzero_occurrences'] ||= 1
           @event['check']       ||= Hash.new
           @event['client']      ||= Hash.new
         rescue => e

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -79,6 +79,18 @@ class TestFilterExternal < MiniTest::Unit::TestCase
     assert_match(/^only handling every/, output)
   end
 
+  def test_state_changed_resolve_enough_occurrences_ten
+    event = {
+    'client' => { 'name' => 'test' },
+    'check' => { 'name' => 'test', 'occurrences' => 3, 'history' => %w[2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 1 1 1 0]},
+    'occurrences' => 10,
+    'action' => 'resolve'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/^Event:/, output)
+  end
+
   def test_refresh_bypass
     event = {
       'client' => { 'name' => 'test' },


### PR DESCRIPTION
Currently handlers ignore RESOLVE (status 0) after an error if there's a 2 (or anything else) in the way.
This isn't a perfect solution, but I believe it solves >90%
Open question: what should sensu do with a status history like 1,2,1,2,1 ?