### PR TITLE
sensu #1067: handle sequences like 1 1 1 2 0 a little better

### DIFF
--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'json'
 
 class TestFilterExternal < MiniTest::Unit::TestCase
   include SensuPluginTestHelper
@@ -6,6 +7,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
   def setup
     set_script 'external/handle-filter'
   end
+
 
   def test_create_not_enough_occurrences
     event = {
@@ -112,5 +114,53 @@ class TestFilterExternal < MiniTest::Unit::TestCase
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/dependency event exists/, output)
+  end
+
+  def test_state_changed_resolve_after_fail
+   event = {
+   'client' => { 'name' => 'test' },
+   'check' => { 'name' => 'test', 'occurrences' => 3, 'history' => %w[1 1 1 0]},
+   'occurrences' => 3,
+   'action' => 'resolve'
+   }
+   output = run_script_with_input(JSON.generate(event))
+   assert_equal(0, $?.exitstatus)
+   assert_match(/^Event:/, output)
+  end
+
+  def test_resolve_after_fail_then_nonzero_state_change
+   event = {
+   'client' => { 'name' => 'test' },
+   'check' => { 'name' => 'test', 'occurrences' => 3, 'history' => %w[1 1 1 2 0]},
+   'occurrences' => 1,
+   'action' => 'resolve'
+   }
+   output = run_script_with_input(JSON.generate(event))
+   assert_equal(0, $?.exitstatus)
+   assert_match(/^Event:/, output)
+  end
+
+  def test_resolve_after_fail_then_extra_nonzero_state_change
+   event = {
+   'client' => { 'name' => 'test' },
+   'check' => { 'name' => 'test', 'occurrences' => 3, 'history' => %w[1 1 1 2 2 0]},
+   'occurrences' => 1,
+   'action' => 'resolve'
+   }
+   output = run_script_with_input(JSON.generate(event))
+   assert_equal(0, $?.exitstatus)
+   assert_match(/^Event:/, output)
+  end
+
+  def IGNORE_BROKEN_test_resolve_after_fail_then_multiple_nonzero_state_change
+    event = {
+      'client' => { 'name' => 'test' },
+      'check' => { 'name' => 'test', 'occurrences' => 3, 'history' => %w[1 1 1 2 3 0]},
+      'occurrences' => 1,
+      'action' => 'resolve'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/^Event:/, output)
   end
 end


### PR DESCRIPTION
This solves the problems I've been having where in a sequence of 1,1,1,2,0 the two hides subsequent 0s from handlers.  
This does *NOT* solve more complex broken sequences, like 1,1,1,2,3,0.  For that we'd need 1+ of:
 - a better regex
 - a "nonzero_occurences" counter
 - something clever with a "last zero" timestamp