### PR TITLE
Don't output an empty args array for graphite metric 

### DIFF
--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -19,11 +19,13 @@ module Sensu
 
         class Graphite < Sensu::Plugin::CLI
           def output(*args)
-            if args[0].is_a?(Exception) || args[1].nil?
-              puts args[0].to_s
-            else
-              args[2] ||= Time.now.to_i
-              puts args[0..2].join("\s")
+            unless args.empty?
+              if args[0].is_a?(Exception) || args[1].nil?
+                puts args[0].to_s
+              else
+                args[2] ||= Time.now.to_i
+                puts args[0..2].join("\s")
+              end
             end
           end
         end


### PR DESCRIPTION
Given the following simple graphite metric

```
# cat test.rb
require 'sensu-plugin/metric/cli'

class DerpMetrics < Sensu::Plugin::Metric::CLI::Graphite
  def run
    output("derp.metric-name", 9876)
    ok
  end
end
```
When you run this metric you will see the following:

```
ruby ./test.rb
derp.metric-name 9876 1458766713

```

On the sensu side if you run this metric you will see the following:
```
"output":"derp.metric-name 9876 1458766713\n\n"
```
If you watch logs on your graphite relays you will see the following in the logs:
```
 invalid line () received from client 127.0.0.1:44116, ignoring
```

This fixes issues specifically in graphite metrics where sensu will
append an extra '\n' to the metrics it sends to graphite and will cause
errors on the graphite relays.

With the following change running this test locally returns no more new-line
```
 bundle exec ruby ~/test.rb
derp.metric-name 9876 1458766934
```

and the sensu check output returns
```
"output":"derp.metric-name 9876 1458766713\n"
```
as expected.