### PR TITLE
Check config_file existence because the file is put in tmp directory.

### DIFF
--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -3,9 +3,9 @@ module Sensu
     module Utils
 
       def config_files
-        if ENV['SENSU_LOADED_TEMPFILE']
+        if ENV['SENSU_LOADED_TEMPFILE'] && File.file?(ENV['SENSU_LOADED_TEMPFILE'])
           IO.read(ENV['SENSU_LOADED_TEMPFILE']).split(':')
-        elsif ENV['SENSU_CONFIG_FILES']
+        elsif ENV['SENSU_CONFIG_FILES'] && File.file?(ENV['SENSU_CONFIG_FILES'])
           ENV['SENSU_CONFIG_FILES'].split(':')
         else
           ['/etc/sensu/config.json'] + Dir['/etc/sensu/conf.d/**/*.json']


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Maybe no

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

Not new plugin

#### Purpose

I'm using the sensu handler but it gets died several days after restarting sensu-server.
I found the following error in sensu-server.log.

```
/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:7:in `read': No such file or directory - /tmp/sensu_server_loaded_files (Errno::ENOENT)
","	from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:7:in `config_files'
","	from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:20:in `settings'
","	from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:104:in `filter_repeated'
","	from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:30:in `filter'
","	from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:54:in `block in <class:Handler>'
```

SENSU_LOADED_TEMPFILE is created on tmp directory. So this file is removed without any notices by OS. I think check the existence of the file.
It might be better to rescue Errno::ENOENT to be sure to check the realtime file existence but I adopted simpler checking.

