### PR TITLE
exit unknown on exception or bad args

### DIFF
--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -59,11 +59,11 @@ module Sensu
             exit e.status
           rescue OptionParser::InvalidOption => e
             puts "Invalid check argument(s): #{e.message}, #{e.backtrace}"
-            exit 1
+            exit 3
           rescue Exception => e
             # This can't call check.critical, as the check may have failed to construct
             puts "Check failed to run: #{e.message}, #{e.backtrace}"
-            exit 2
+            exit 3
           end
           check.warning "Check did not exit! You should call an exit code method."
         end

--- a/test/external_check_test.rb
+++ b/test/external_check_test.rb
@@ -39,7 +39,7 @@ class TestCheckExternal < MiniTest::Unit::TestCase
 
   def test_exception
     output = run_script '-f'
-    assert $?.exitstatus == 2 && output.include?('failed')
+    assert $?.exitstatus == 3 && output.include?('failed')
   end
 
   def test_argv
@@ -49,6 +49,6 @@ class TestCheckExternal < MiniTest::Unit::TestCase
 
   def test_bad_commandline
     output = run_script '--doesnotexist'
-    assert $?.exitstatus == 1 && output.include?('doesnotexist') && output.include?('invalid option')
+    assert $?.exitstatus == 3 && output.include?('doesnotexist') && output.include?('invalid option')
   end
 end


### PR DESCRIPTION
when a plugin throws an unexpected exception we should exit(3) unknown.
As it means the plugin was unable to signal warning or critical itself
meaning the state of the thing being checked is unknown. This commit
changes the behavior from exit(2) critical which generally results in
someone getting paged with a false alarm.

Similarly, when someone deploys a check and has given it the wrong
arguments we should also exit(3) unknown. We don't know the state of the
thing we are attempting to check.  We only know the check was
misconfigured because the options are wrong.
