### PR TITLE
exit unknown on script load/compile fail

### DIFF
--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -51,6 +51,7 @@ module Sensu
       end
 
       at_exit do
+        exit 3 if $!
         if @@autorun
           begin
             check = @@autorun.new

--- a/test/external/bad-require
+++ b/test/external/bad-require
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require 'sensu-plugin/check/cli'
+require 'timederp' # hopefully never exists..

--- a/test/external_check_test.rb
+++ b/test/external_check_test.rb
@@ -51,4 +51,11 @@ class TestCheckExternal < MiniTest::Unit::TestCase
     output = run_script '--doesnotexist'
     assert $?.exitstatus == 1 && output.include?('doesnotexist') && output.include?('invalid option')
   end
+
+  def test_bad_require
+    set_script 'external/bad-require' # TODO better way to switch scripts?
+    output = run_script '2>&1'
+    assert_equal($?.exitstatus, 3)
+    assert_match(/LoadError/, output)
+  end
 end


### PR DESCRIPTION
fixes issue #104

If we are entering the at_exit handler and an exception has already been
thrown then just exit(3) unknown. This will catch LoadErrors and other
errors failing to compile the check script. At least the ones that don't
prevent us from installing the at_exit handler.