### PR TITLE
Use the same deep_merge code that sensu core uses

### DIFF
--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -48,19 +48,19 @@ module Sensu
   end
 end
 
-# Monkey Patching.
-
-class Array
-  def deep_merge(other_array, &merger)
-    concat(other_array).uniq
-  end
-end
-
 class Hash
-  def deep_merge(other_hash, &merger)
-    merger ||= proc do |key, old_value, new_value|
-      old_value.deep_merge(new_value, &merger) rescue new_value
+  def deep_merge(hash_one, hash_two)
+    merged = hash_one.dup
+    hash_two.each do |key, value|
+      merged[key] = case
+      when hash_one[key].is_a?(Hash) && value.is_a?(Hash)
+        deep_merge(hash_one[key], value)
+      when hash_one[key].is_a?(Array) && value.is_a?(Array)
+        hash_one[key].concat(value).uniq
+      else
+        value
+      end
     end
-    merge(other_hash, &merger)
+    merged
   end
 end

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -17,7 +17,7 @@ module Sensu
       end
 
       def settings
-        @settings ||= config_files.map {|f| load_config(f) }.reduce {|a, b| a.deep_merge(b) }
+        @settings ||= config_files.map {|f| load_config(f) }.reduce {|a, b| deep_merge(a, b) }
       end
 
       def read_event(file)
@@ -44,23 +44,21 @@ module Sensu
           Net::HTTP::Put
         end
       end
-    end
-  end
-end
 
-class Hash
-  def deep_merge(hash_one, hash_two)
-    merged = hash_one.dup
-    hash_two.each do |key, value|
-      merged[key] = case
-      when hash_one[key].is_a?(Hash) && value.is_a?(Hash)
-        deep_merge(hash_one[key], value)
-      when hash_one[key].is_a?(Array) && value.is_a?(Array)
-        hash_one[key].concat(value).uniq
-      else
-        value
+      def deep_merge(hash_one, hash_two)
+        merged = hash_one.dup
+        hash_two.each do |key, value|
+          merged[key] = case
+          when hash_one[key].is_a?(Hash) && value.is_a?(Hash)
+            deep_merge(hash_one[key], value)
+          when hash_one[key].is_a?(Array) && value.is_a?(Array)
+            hash_one[key].concat(value).uniq
+          else
+            value
+          end
+        end
+        merged
       end
     end
-    merged
   end
 end

--- a/test/deep_merge_test.rb
+++ b/test/deep_merge_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'sensu-plugin/utils'
+
+class TestDeepMerge < MiniTest::Test
+  include SensuPluginTestHelper
+  include Sensu::Plugin::Utils
+
+  def test_hash
+    merged = deep_merge({:a => "a"}, {:b => "b"})
+    assert(merged == {:a => "a", :b => "b"})
+  end
+
+  def test_nested_hash
+    merged = deep_merge({:a => {:b => "c"}}, {:a => {:d => "e"}})
+    assert(merged == {:a => {:b => "c", :d => "e"}})
+  end
+
+  def test_nested_array
+    merged = deep_merge({:a => ["b"]}, {:a => ["c"]})
+    assert(merged, {:a => ["b", "c"]})
+  end
+
+  def test_conflicting_types
+    merged = deep_merge({:a => {:b => "c"}}, {:a => ["d"]})
+    assert(merged, {:a => {:b => "c"}})
+  end
+end


### PR DESCRIPTION
The deep merge functionality in sensu-plugin, which is used when building up the the `@settings` object, currently behaves differently than Sensu Core. Sensu Core will only try to merge two objects if they are of the same type (e.g. two hashes or two arrays). I've copied over the `deep_merge` function from Sensu Core directly and all of the rspec tests seem to be passing.