### PR TITLE
MiniTest::Unit::TestCase is now Minitest::Test

### DIFF
--- a/test/external_check_test.rb
+++ b/test/external_check_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestCheckExternal < MiniTest::Unit::TestCase
+class TestCheckExternal < MiniTest::Test
   include SensuPluginTestHelper
 
   def setup

--- a/test/external_handler_argument_test.rb
+++ b/test/external_handler_argument_test.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'minitest/autorun'
 require 'json'
 
-class TestHandlerArgumentExternal < MiniTest::Unit::TestCase
+class TestHandlerArgumentExternal < MiniTest::Test
   include SensuPluginTestHelper
 
   def test_default

--- a/test/external_handler_test.rb
+++ b/test/external_handler_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'json'
 
-class TestHandlerExternal < MiniTest::Unit::TestCase
+class TestHandlerExternal < MiniTest::Test
   include SensuPluginTestHelper
 
   def setup

--- a/test/external_metric_test.rb
+++ b/test/external_metric_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestMetricExternal < MiniTest::Unit::TestCase
+class TestMetricExternal < MiniTest::Test
   include SensuPluginTestHelper
 
   def setup
@@ -14,7 +14,7 @@ class TestMetricExternal < MiniTest::Unit::TestCase
 
 end
 
-class TestGraphiteMetricExternal < MiniTest::Unit::TestCase
+class TestGraphiteMetricExternal < MiniTest::Test
   include SensuPluginTestHelper
 
   def setup
@@ -28,7 +28,7 @@ class TestGraphiteMetricExternal < MiniTest::Unit::TestCase
 
 end
 
-class TestStatsdMetricExternal < MiniTest::Unit::TestCase
+class TestStatsdMetricExternal < MiniTest::Test
   include SensuPluginTestHelper
 
   def setup

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestFilterExternal < MiniTest::Unit::TestCase
+class TestFilterExternal < MiniTest::Test
   include SensuPluginTestHelper
 
   def setup

--- a/test/handle_helper_test.rb
+++ b/test/handle_helper_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestHandleHelpers < MiniTest::Unit::TestCase
+class TestHandleHelpers < MiniTest::Test
   include SensuPluginTestHelper
 
   def setup


### PR DESCRIPTION
Fixes the `MiniTest::Unit::TestCase is now Minitest::Test` lines that would be outputted with each MiniSpec run.