### PR TITLE
[WIP] Use sensu-json instead of json gem

### DIFF
--- a/lib/sensu-mutator.rb
+++ b/lib/sensu-mutator.rb
@@ -6,7 +6,7 @@
 # DESCRIPTION:
 #   Base mutator class.  All you need to do is extend this class and implement a
 #   #mutate function.  Uses the autorun feature just like sensu-handler and sensu-plugin/cli
-# 
+#
 # Example Implementation: described https://sensuapp.org/docs/latest/mutators#example-mutator-plugin
 #
 # class Helper < Sensu::Mutator
@@ -26,7 +26,7 @@
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
-require 'json'
+require 'sensu/json'
 require 'sensu-plugin/utils'
 require 'mixlib/cli'
 
@@ -48,7 +48,7 @@ module Sensu
     end
 
     def dump
-      puts JSON.dump(@event)
+      puts Sensu::JSON.dump(@event)
     end
 
     # This works just like Plugin::CLI's autorun.

--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -1,5 +1,5 @@
 require 'sensu-plugin/cli'
-require 'json'
+require 'sensu/json'
 
 module Sensu
   module Plugin
@@ -12,7 +12,7 @@ module Sensu
               puts obj.to_s
             elsif obj.is_a?(Hash)
               obj['timestamp'] ||= Time.now.to_i
-              puts ::JSON.generate(obj)
+              puts Sensu::JSON.dump(obj)
             end
           end
         end

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -13,7 +13,7 @@ module Sensu
       end
 
       def load_config(filename)
-        JSON.parse(File.open(filename, 'r').read) rescue Hash.new
+        JSON.load(File.open(filename, 'r').read) rescue Hash.new
       end
 
       def settings
@@ -22,10 +22,10 @@ module Sensu
 
       def read_event(file)
         begin
-          @event = ::JSON.parse(file.read)
-          @event['occurrences'] ||= 1
-          @event['check']       ||= Hash.new
-          @event['client']      ||= Hash.new
+          @event = Sensu::JSON.load(file.read)
+          @event[:occurrences] ||= 1
+          @event[:check]       ||= Hash.new
+          @event[:client]      ||= Hash.new
         rescue => e
           puts 'error reading event: ' + e.message
           exit 0

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*.rb']
   s.test_files    = Dir['test/*.rb']
 
-  s.add_dependency('json')
+  s.add_dependency('sensu-json', '2.0.0')
   s.add_dependency('mixlib-cli', '>= 1.5.0')
 
   s.add_development_dependency('rake')

--- a/test/external_handler_argument_test.rb
+++ b/test/external_handler_argument_test.rb
@@ -1,25 +1,25 @@
 require 'rubygems'
 require 'minitest/autorun'
-require 'json'
+require 'sensu/json'
 
 class TestHandlerArgumentExternal < MiniTest::Unit::TestCase
   include SensuPluginTestHelper
 
   def test_default
     set_script 'external/handle-argument'
-    output = run_script_with_input(JSON.generate({}))
+    output = run_script_with_input(Sensu::JSON.dump({}))
     assert $?.exitstatus == 0 && output =~ /Value:\sfoo/
   end
 
   def test_short
     set_script 'external/handle-argument -t bar'
-    output = run_script_with_input(JSON.generate({}))
+    output = run_script_with_input(Sensu::JSON.dump({}))
     assert $?.exitstatus == 0 && output =~ /Value:\sbar/
   end
 
   def test_long
     set_script 'external/handle-argument --test bar'
-    output = run_script_with_input(JSON.generate({}))
+    output = run_script_with_input(Sensu::JSON.dump({}))
     assert $?.exitstatus == 0 && output =~ /Value:\sbar/
   end
 end

--- a/test/external_handler_test.rb
+++ b/test/external_handler_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'json'
+require 'sensu/json'
 
 class TestHandlerExternal < MiniTest::Unit::TestCase
   include SensuPluginTestHelper
@@ -14,13 +14,13 @@ class TestHandlerExternal < MiniTest::Unit::TestCase
       'check' => { 'name' => 'test' },
       'occurrences' => 1,
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert $?.exitstatus == 0 && output =~ /Event:.*test/
   end
 
   def test_missing_keys
     event = {}
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert $?.exitstatus == 0 && output =~ /Event:/
   end
 

--- a/test/external_metric_test.rb
+++ b/test/external_metric_test.rb
@@ -8,8 +8,8 @@ class TestMetricExternal < MiniTest::Unit::TestCase
   end
 
   def test_ok
-    output = JSON.parse(run_script)
-    assert $?.exitstatus == 0 && output.key?('timestamp')
+    output = Sensu::JSON.load(run_script)
+    assert $?.exitstatus == 0 && output.key?(:timestamp)
   end
 
 end

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -14,7 +14,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 1,
       'action' => 'create'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^not enough occurrences/, output)
   end
@@ -26,7 +26,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 2,
       'action' => 'create'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^Event:/, output)
   end
@@ -38,7 +38,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 1,
       'action' => 'resolve'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^not enough occurrences/, output)
   end
@@ -50,7 +50,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 2,
       'action' => 'resolve'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^Event:/, output)
   end
@@ -62,7 +62,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 61,
       'action' => 'create'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^Event:/, output)
   end
@@ -74,7 +74,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 60,
       'action' => 'create'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^only handling every/, output)
   end
@@ -86,7 +86,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 60,
       'action' => 'create'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^Event:/, output)
   end
@@ -98,7 +98,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'occurrences' => 60,
       'action' => 'create'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/^Event:/, output)
   end
@@ -109,7 +109,7 @@ class TestFilterExternal < MiniTest::Unit::TestCase
       'check' => { 'name' => 'test', 'dependencies' => ['foo', 'bar'] },
       'occurrences' => 1
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match(/dependency event exists/, output)
   end

--- a/test/handle_helper_test.rb
+++ b/test/handle_helper_test.rb
@@ -20,19 +20,19 @@ class TestHandleHelpers < MiniTest::Unit::TestCase
       'occurrences' => 1,
       'action' => 'create'
     }
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match("test/test : test\n", output)
     event['check']['source'] = 'switch-x'
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match("switch-x/test : test\n", output)
     event['check']['description'] = 'y is broken'
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match("y is broken\n", output)
     event['check']['notification'] = 'z is broken'
-    output = run_script_with_input(JSON.generate(event))
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
     assert_match("z is broken\n", output)
   end

--- a/test/mutator_test.rb
+++ b/test/mutator_test.rb
@@ -7,17 +7,17 @@ class TestMutatorHelpers < MiniTest::Test
   include SensuPluginTestHelper
   def test_base_mutator
     set_script 'external/mutator-trivial'
-    event = JSON.parse(fixture('basic_event.json').read)
-    output = run_script_with_input(JSON.generate(event))
+    event = Sensu::JSON.load(fixture('basic_event.json').read)
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
-    assert_equal(event, JSON.parse(output))
+    assert_equal(event, Sensu::JSON.load(output))
   end
 
   def test_external_mutator
     set_script 'external/mutator-helpers'
-    event = JSON.parse(fixture('basic_event.json').read)
-    output = run_script_with_input(JSON.generate(event))
+    event = Sensu::JSON.load(fixture('basic_event.json').read)
+    output = run_script_with_input(Sensu::JSON.dump(event))
     assert_equal(0, $?.exitstatus)
-    assert_equal(true, JSON.parse(output)['mutated'])
+    assert_equal(true, Sensu::JSON.load(output)[:mutated])
   end
 end


### PR DESCRIPTION
This PR replaces the json gem with the sensu-json gem as per #127. There are some limitations that should be considered before this PR should be considered a candidate for merging:

Advantages:

* The same JSON library as Sensu Core & Sensu Enterprise
* Performance benefits

Disadvantages:

* It wraps the Oj gem (except under JRuby) which has C bindings that must be compiled
* Parsed JSON (via `Sensu::JSON.load`) only allows keys to be accessed by symbols -- I think this may break a lot of plugins

I'm not currently in favour of having this merged as-is. I think we need to ensure keys can be accessed via both strings & symbols. I don't have much of an opinion regarding Oj & C bindings as many Sensu plugins already have gem dependencies with C bindings.

Any feedback, criticism, or corrections will all be greatly appreciated!