### PR TITLE
introduce acknowledgments

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -159,7 +159,7 @@ module Sensu
 
       return false unless @stash.code == '200'
 
-      if event_resolved? && stash_is_acknowledgement?
+      if event_resolved? && expire_on_resolve?
         delete_stash(path)
         false
       else
@@ -168,8 +168,8 @@ module Sensu
     end
 
     # uses most recent stash from get_stash()
-    def stash_is_acknowledgement?
-      JSON.parse(@stash.body)['type'] == 'acknowledgment'
+    def expire_on_resolve?
+      JSON.parse(@stash.body)['expire_on_resolve'] == true
     rescue JSON::ParserError
       false
     end

--- a/test/external/handle-acked
+++ b/test/external/handle-acked
@@ -35,7 +35,7 @@ class TestHandleAcked < Sensu::Handler
 
       obj.define_singleton_method(:body) do
         if config[:acked]
-          '{"type":"acknowledgment","reason":"because"}'
+          '{"expire_on_resolve":true,"reason":"because"}'
         elsif config[:stashed]
           '{"reason":"because"}'
         else

--- a/test/external/handle-acked
+++ b/test/external/handle-acked
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+
+require 'sensu-handler'
+
+class TestHandleAcked < Sensu::Handler
+
+  option :acked, long: '--acked'
+  option :stashed, long: '--stashed'
+
+  def handle
+    puts "handled"
+  end
+
+  def api_request(*args)
+    throw "shouldn't be called"
+  end
+
+  def get_stash(path)
+    @stash ||= duck_mock_stash
+  end
+
+  # note all stashes treated the same
+  def duck_mock_stash
+    config = self.config # add to local scope for capture in blocks below
+    Object.new.tap do |obj|
+      obj.define_singleton_method(:code) do
+        if config[:acked] || config[:stashed]
+          '200'
+        else
+          '404'
+        end
+      end
+
+      obj.define_singleton_method(:body) do
+        if config[:acked]
+          '{"type":"acknowledgment","reason":"because"}'
+        elsif config[:stashed]
+          '{"reason":"because"}'
+        else
+          ""
+        end
+      end
+    end
+  end
+
+  def delete_stash(path)
+    puts "deleting stash #{path}"
+  end
+
+end

--- a/test/external_ack_test.rb
+++ b/test/external_ack_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+require 'json'
+
+class TestExternalAck < MiniTest::Test
+  include SensuPluginTestHelper
+
+  attr_accessor :output
+  attr_accessor :event
+
+  def event_json
+    JSON.generate(@event)
+  end
+
+  def run_script_with_input(*args)
+    args << '2<&1'
+    @output = super(*args)
+  end
+
+  def action(arg)
+    event['action'] = arg.to_s
+  end
+
+  def setup
+    set_script 'external/handle-acked'
+    @event = {
+      'client'      => { 'name' => 'test' },
+      'check'       => { 'name' => 'test' },
+      'occurrences' => 1,
+    }
+  end
+
+  def test_resolve_when_not_silenced
+    action :resolve
+    run_script_with_input(event_json)
+    assert_match(/^handled/, @output)
+    refute_match(/^deleting stash/, @output)
+  end
+
+  def test_resolve_when_acked
+    action :resolve
+    run_script_with_input(event_json, '--acked')
+    assert_match(/^handled/, @output)
+    assert_match(/^deleting stash/, @output)
+  end
+
+  def test_resolve_when_silenced
+    action :resolve
+    run_script_with_input(event_json, '--stashed')
+    assert_match(/alerts silenced/, @output)
+  end
+
+  def test_create_when_acked
+    action :create
+    run_script_with_input(event_json, '--acked')
+    assert_match(/alerts silenced/, @output)
+  end
+
+  def test_create_when_silenced
+    action :create
+    run_script_with_input(event_json, '--stashed')
+    assert_match(/alerts silenced/, @output)
+  end
+
+  def test_create_when_not_silenced
+    action :create
+    run_script_with_input(event_json)
+    assert_match(/handled/, @output)
+  end
+
+end


### PR DESCRIPTION
short version:  if a stash has ~~type: "acknowledgment"~~ `expire_on_resolve: true` then when the event is resolved delete the stash and  handle the event.

I propose people need two workflows with regards to silencing alerts.

1. downtime, the thing being checked may fail and resolve multiple times
during some time interval, alerts should be filtered.

2. acknowledgment, the thing being checked just failed, someone has
acknowledged this fact and future failing alerts should be filtered,
until the check is resolved. the resolution event should be handled.

right now sensu-handler only supports the notion of downtime with it's
silence stashes. this has a few problems related to an acknowledgment
workflow

- if the event is resolved during the downtime window the handler is
  prevented from handling it. for example say a pagerduty alert was
  created on event create but the resolve event was filtered
  it requires manually resolving the pager duty event.
- user must remember to remove the stash. or guess an appropriate expiration time.
  (in my observation our users never set one. and then forget them)
- if downtime is too long, someone may believe they fixed the issue only
  to have it come back and not alert again until the downtime window is
  closed.
- if downtime window is too short, we are needlessly alerted more when
  it expires.

This commit introduces acknowledgments by way of the type field in the
normal /silence/* stashes if the type field is set to 'acknowledgment'
and the event action is resolve then the stash will be deleted and the
event processed.


a note on testing:

I wasn't sure how to test this.  I did my best to imitate the current style of
tests which is essentially stubbing and mocking via a subclass in an external script and signaling back expectations via stdout.  mine still ended up
more complicated than any existing ones.  

I also tried to just use minitest  and new() up a handler object making use of
Sensu::Handler.disable_autorun but I got lost in the world of minitest mocks.
if someone thinks that's better let me know I can try again.

An alternate abandoned approach:

I initially considered having acknowledgments as their own namespace in the
stashes, such as /acknowledgment/:client/:name, however I decided that this
would not have backwards compatibility with existing systems checking for
silenced alerts and would add to the number of api calls made per handled
event.