### PR TITLE
Deprecate event filtering in Sensu::Handler

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -27,25 +27,35 @@ module Sensu
 
     # Filters exit the proccess if the event should not be handled.
     #
-    # Filtering repeated events is deprecated and will be removed
-    # in a future release.
+    # Filtering events is deprecated and will be removed in a future release.
     #
     def filter
-      filter_disabled
-      filter_silenced
-      filter_dependencies
       if deprecated_filtering_enabled?
-        puts 'warning: occurrence filtering is deprecated, see http://bit.ly/sensu-plugin'
-        filter_repeated
+        puts 'warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
+        filter_disabled
+        filter_silenced
+        filter_dependencies
+        if deprecated_occurrence_filtering_enabled?
+          puts 'warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
+          filter_repeated
+        end
       end
     end
 
-    # Evaluates whether the check definition for the event explicitly disables
-    # deprecated occurrence filtering behavior. Defaults to true
+    # Evaluates whether the event should be processed by any of the filter methods in
+    # this library. Defaults to true (i.e. deprecated filters are run by default.)
     #
     # @return [TrueClass, FalseClass]
     def deprecated_filtering_enabled?
-      @event['check']['use_deprecated_filtering'].nil? || @event['check']['use_deprecated_filtering'] == true
+      @event['check']['enable_deprecated_filtering'].nil? || @event['check']['enable_deprecated_filtering'] == true
+    end
+
+    # Evaluates whether the event should be processed by the filter_repeated method. Defaults to true (i.e.
+    # filter_repeated will filter events by default)
+    #
+    # @return [TrueClass, FalseClass]
+    def deprecated_occurrence_filtering_enabled?
+      @event['check']['enable_deprecated_occurrence_filtering'].nil? || @event['check']['enable_deprecated_occurrence_filtering'] == true
     end
 
     # This works just like Plugin::CLI's autorun.
@@ -112,7 +122,7 @@ module Sensu
         raise "api.json settings not found."
       end
       domain = api_settings['host'].start_with?('http') ? api_settings['host'] : 'http://' + api_settings['host']
-      uri = URI("#{domain}:#{api_settings['port']}#{path}") 
+      uri = URI("#{domain}:#{api_settings['port']}#{path}")
       req = net_http_req_class(method).new(uri)
       if api_settings['user'] && api_settings['password']
         req.basic_auth(api_settings['user'], api_settings['password'])

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -24,14 +24,21 @@ module Sensu
       puts 'ignoring event -- no handler defined'
     end
 
-    # Filters exit the proccess if the event should not be handled.
-    # Implementation of the default filters is below.
 
+    # Filters exit the proccess if the event should not be handled.
+    #
+    # Filtering in this library is deprecated and will be removed
+    # in a future release.
+    #
     def filter
-      filter_disabled
-      filter_repeated
-      filter_silenced
-      filter_dependencies
+      filtering_enabled = @event['check']['use_deprecated_filtering']
+      if filtering_enabled.nil? || filtering_enabled == true
+        puts 'warning: sensu-plugin event filtering is deprecated'
+        filter_disabled
+        filter_repeated
+        filter_silenced
+        filter_dependencies
+      end
     end
 
     # This works just like Plugin::CLI's autorun.

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -27,18 +27,25 @@ module Sensu
 
     # Filters exit the proccess if the event should not be handled.
     #
-    # Filtering in this library is deprecated and will be removed
+    # Filtering repeated events is deprecated and will be removed
     # in a future release.
     #
     def filter
-      filtering_enabled = @event['check']['use_deprecated_filtering']
-      if filtering_enabled.nil? || filtering_enabled == true
-        puts 'warning: sensu-plugin event filtering is deprecated'
-        filter_disabled
+      filter_disabled
+      filter_silenced
+      filter_dependencies
+      if deprecated_filtering_enabled?
+        puts 'warning: occurrence filtering is deprecated, see http://bit.ly/sensu-plugin'
         filter_repeated
-        filter_silenced
-        filter_dependencies
       end
+    end
+
+    # Evaluates whether the check definition for the event explicitly disables
+    # deprecated occurrence filtering behavior. Defaults to true
+    #
+    # @return [TrueClass, FalseClass]
+    def deprecated_filtering_enabled?
+      @event['check']['use_deprecated_filtering'].nil? || @event['check']['use_deprecated_filtering'] == true
     end
 
     # This works just like Plugin::CLI's autorun.

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -115,7 +115,7 @@ class TestFilterExternal < MiniTest::Test
   end
 
   def filter_deprecation_string
-    'warning: sensu-plugin event filtering is deprecated'
+    'warning: occurrence filtering is deprecated, see http://bit.ly/sensu-plugin'
   end
 
   def test_filter_deprecation_warning_exists

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -115,10 +115,10 @@ class TestFilterExternal < MiniTest::Test
   end
 
   def filter_deprecation_string
-    'warning: occurrence filtering is deprecated, see http://bit.ly/sensu-plugin'
+    'warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
   end
 
-  def test_filter_deprecation_warning_exists
+  def test_filter_deprecation_warning_exists_by_default
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test', 'refresh' => 30 },
@@ -130,13 +130,25 @@ class TestFilterExternal < MiniTest::Test
     assert_match(/#{filter_deprecation_string}/, output)
   end
 
-  def test_filter_deprecation_warning_does_not_exist_when_disabled
+  def test_filter_deprecation_warning_exists_when_explicitly_enabled
+    event = {
+      'client' => { 'name' => 'test' },
+      'check' => { 'name' => 'test', 'refresh' => 30, 'enable_deprecated_filtering' => true },
+      'occurrences' => 60,
+      'action' => 'create'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/#{filter_deprecation_string}/, output)
+  end
+
+  def test_filter_deprecation_warning_does_not_exist_when_explicitly_disabled
     event = {
       'client' => { 'name' => 'test' },
       'check' => {
         'name' => 'unfiltered test',
         'refresh' => 30,
-        'use_deprecated_filtering' => false
+        'enable_deprecated_filtering' => false
       },
       'occurrences' => 60,
       'action' => 'create',
@@ -144,5 +156,53 @@ class TestFilterExternal < MiniTest::Test
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
     refute_match(/#{filter_deprecation_string}/, output)
+  end
+
+  def occurrence_filter_deprecation_string
+    'warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
+  end
+
+  def test_occurrence_filter_deprecation_warning_exists_by_default
+    event = {
+      'client' => { 'name' => 'test' },
+      'check' => { 'name' => 'test', 'refresh' => 30 },
+      'occurrences' => 60,
+      'action' => 'create'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/#{occurrence_filter_deprecation_string}/, output)
+  end
+
+  def test_occurrence_filter_deprecation_warning_exists_when_explicitly_enabled
+    event = {
+      'client' => { 'name' => 'test' },
+      'check' => {
+        'name' => 'test',
+        'refresh' => 30,
+        'enable_deprecated_occurrence_filtering' => true
+      },
+      'occurrences' => 60,
+      'action' => 'create'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/#{occurrence_filter_deprecation_string}/, output)
+  end
+
+  def test_occurrence_filter_deprecation_warning_does_not_exist_when_explicitly_disabled
+    event = {
+      'client' => { 'name' => 'test' },
+      'check' => {
+        'name' => 'unfiltered test',
+        'refresh' => 30,
+        'enable_deprecated_occurrence_filtering' => false
+      },
+      'occurrences' => 60,
+      'action' => 'create',
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    refute_match(/#{occurrence_filter_deprecation_string}/, output)
   end
 end

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -113,4 +113,36 @@ class TestFilterExternal < MiniTest::Test
     assert_equal(0, $?.exitstatus)
     assert_match(/dependency event exists/, output)
   end
+
+  def filter_deprecation_string
+    'warning: sensu-plugin event filtering is deprecated'
+  end
+
+  def test_filter_deprecation_warning_exists
+    event = {
+      'client' => { 'name' => 'test' },
+      'check' => { 'name' => 'test', 'refresh' => 30 },
+      'occurrences' => 60,
+      'action' => 'create'
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    assert_match(/#{filter_deprecation_string}/, output)
+  end
+
+  def test_filter_deprecation_warning_does_not_exist_when_disabled
+    event = {
+      'client' => { 'name' => 'test' },
+      'check' => {
+        'name' => 'unfiltered test',
+        'refresh' => 30,
+        'use_deprecated_filtering' => false
+      },
+      'occurrences' => 60,
+      'action' => 'create',
+    }
+    output = run_script_with_input(JSON.generate(event))
+    assert_equal(0, $?.exitstatus)
+    refute_match(/#{filter_deprecation_string}/, output)
+  end
 end


### PR DESCRIPTION
## Description
The filtering  methods in this library are computationally expensive and confusing to users. See http://bit.ly/sensu-plugin for more detail.

This change adds logic which honors the `check.enable_deprecated_filtering` and `check.enable_deprecated_occurrence_filtering` event attributes:
* When `check.use_deprecated_filtering` is explicitly set to `false`, filtering in this library becomes a noop.
* When `check.use_deprecated_occurrence_filtering` is explicitly set to `false`, occurrence filtering in this library becomes a noop.

When check results are to be processed by the `filter_repeated` method (enabled by default), a warning will be logged indicating that sensu-plugin event occurrence filtering is deprecated.

The `filter_disabled`, `filter_dependencies` and `filter_silenced` methods will continue to be applied to events. 

## Motivation and Context

As documented in #134 and my blog post at http://bit.ly/sensu-plugin, deprecating and eventually removing the filtering behavior of sensu-plugin will transfer more control to operators instead of trying to cover all cases via this library.

## How Has This Been Tested?

Added tests to validate that:
* deprecation warning messages associated with these filters are printed by default or when explicitly enabled
* deprecation warning messages associated with these filters are not printed when explicitly disabled

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

~~Edit: I've updated the description of this PR to reflect that we've narrowed the focus of this change to the event occurrence filtering in the `filter_repeated` method.~~

Edit: I've updated the description of this PR again to reflect the more granular approach we're now proposing for deprecating these filter behaviors. See https://github.com/sensu-plugins/sensu-plugin/commit/7d089fc762ffa198a997b02f74bf2d5b851cfa51