### PR TITLE
Default API host and port to 127.0.0.1:4567

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  > Previously, if there were two conflicting data types in the same namespace (e.g. a Hash in one file, and an Array in another), sensu-plugin would throw an exception. It will now only use whatever loaded first, which is how Sensu Core handles this problem.
 
+- The api_request method now defaults `api` configuration to `{ "host": "127.0.0.1", "port": 4567 }` when neither the `SENSU_API_URL` environment variable nor the `api` configuration scope is define an API host and port.
+
 ### Fixed
 - Project tests updated to silence warnings by using `Minitest::Test` (#132 via @amdprophet).
 - Now exiting with return code `3` when plugin `require` statements raise an exception. Previously this would cause plugins to exit with status `0`. (#121 via @fessyfoo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  > Previously, if there were two conflicting data types in the same namespace (e.g. a Hash in one file, and an Array in another), sensu-plugin would throw an exception. It will now only use whatever loaded first, which is how Sensu Core handles this problem.
 
-- The api_request method now defaults `api` configuration to `{ "host": "127.0.0.1", "port": 4567 }` when neither the `SENSU_API_URL` environment variable nor the `api` configuration scope is define an API host and port.
+- The api_request method now defaults `api` configuration host 127.0.0.1 and port 4567 when configuration has not been provided via `SENSU_API_URL` environment variable nor Sensu JSON configuration.
 
 ### Fixed
 - Project tests updated to silence warnings by using `Minitest::Test` (#132 via @amdprophet).

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -100,7 +100,6 @@ module Sensu
         @api_settings['host'] ||= '127.0.0.1'
         @api_settings['port'] ||= 4567
       end
-
       @api_settings
     end
 

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -79,22 +79,25 @@ module Sensu
       exit 0
     end
 
+    # Return a hash of API settings derived first from ENV['SENSU_API_URL'] if set,
+    # then Sensu config `api` scope if configured, and finally falling back to
+    # to ipv4 localhost address on default API port.
+    #
+    # @return [Hash]
     def api_settings
-      @api_settings ||= if ENV['SENSU_API_URL']
+      case
+      when ENV['SENSU_API_URL']
         uri = URI(ENV['SENSU_API_URL'])
-        {
+        @api_settings = {
           'host' => uri.host,
           'port' => uri.port,
           'user' => uri.user,
           'password' => uri.password
         }
-      elsif settings['api'].nil? || settings['api'].empty?
-        {
-          'host' => '127.0.0.1',
-          'port' => 4567
-        }
       else
-        settings['api']
+        @api_settings = settings['api'] || {}
+        @api_settings['host'] ||= '127.0.0.1'
+        @api_settings['port'] ||= 4567
       end
     end
 

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -88,6 +88,11 @@ module Sensu
           'user' => uri.user,
           'password' => uri.password
         }
+      elsif settings['api'].nil? || settings['api'].empty?
+        {
+          'host' => '127.0.0.1',
+          'port' => 4567
+        }
       else
         settings['api']
       end
@@ -98,7 +103,7 @@ module Sensu
         raise "api.json settings not found."
       end
       domain = api_settings['host'].start_with?('http') ? api_settings['host'] : 'http://' + api_settings['host']
-      uri = URI("#{domain}:#{api_settings['port']}#{path}") 
+      uri = URI("#{domain}:#{api_settings['port']}#{path}")
       req = net_http_req_class(method).new(uri)
       if api_settings['user'] && api_settings['password']
         req.basic_auth(api_settings['user'], api_settings['password'])

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -85,6 +85,7 @@ module Sensu
     #
     # @return [Hash]
     def api_settings
+      return @api_settings if @api_settings
       case
       when ENV['SENSU_API_URL']
         uri = URI(ENV['SENSU_API_URL'])
@@ -99,6 +100,8 @@ module Sensu
         @api_settings['host'] ||= '127.0.0.1'
         @api_settings['port'] ||= 4567
       end
+
+      @api_settings
     end
 
     def api_request(method, path, &blk)


### PR DESCRIPTION
## Description
This change defaults the configuration for the API to `{ "host": "127.0.0.1", "port": 4567 }` when neither the `SENSU_API_URL` environment variable is set nor an `api` configuration scope is defined in the loaded Sensu settings. Prior to this change, undefined `api` host and port attributes would raise an exception when a plugin attempts to make requests against the Sensu API.

## Motivation and Context
This change is intended as a convenience for users running the API on same compute instance as their Sensu server (as is the behavior under Sensu Enterprise). Closes #95.

## How Has This Been Tested?

Manually tested in local environment.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

With this change, configurations which previously reported the error ["api.json settings not found"](https://github.com/sensu-plugins/sensu-plugin/blob/v1.3.0/lib/sensu-handler.rb#L97-L99) will now attempt to connect to the api on 127.0.0.1:4567. If the API is not listening on this ip and port combination, connection errors will bubble up from Net::HTTP instead. This will likely take longer than simply raising an exception.