### PR TITLE
Require json in utils.rb.

### DIFF
--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Sensu
   module Plugin
     module Utils


### PR DESCRIPTION
Without it, `load_config` simply returns an empty hash for everything,
which in turn makes it so that `settings` is always empty.

You can see this behavior in a minimal check plugin that attempts to
include `utils` without also requiring `json`.

```
require 'sensu-plugin/check/cli'
require 'sensu-plugin/utils'

class JsonCheck < Sensu::Plugin::Check::CLI
  include Sensu::Plugin::Utils

  def run
    if settings['api'].nil?
      critical 'Settings not loaded.'
    else
      ok settings['api']
    end
  end
end
```