### PR TITLE
sensu-handler: filter_repeated never filter resolve events

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -117,6 +117,10 @@ module Sensu
     end
 
     def filter_repeated
+
+      # never filter the resolve event.
+      return if @event['action'] == 'resolve'
+
       defaults = {
         'occurrences' => 1,
         'interval' => 30,
@@ -133,7 +137,7 @@ module Sensu
       if @event['occurrences'] < occurrences
         bail 'not enough occurrences'
       end
-      if @event['occurrences'] > occurrences && @event['action'] == 'create'
+      if @event['occurrences'] > occurrences
         number = refresh.fdiv(interval).to_i
         unless number == 0 || (@event['occurrences'] - occurrences) % number == 0
           bail 'only handling every ' + number.to_s + ' occurrences'

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -40,7 +40,7 @@ class TestFilterExternal < MiniTest::Test
     }
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
-    assert_match(/^not enough occurrences/, output)
+    assert_match(/^Event:/, output)
   end
 
   def test_resolve_enough_occurrences


### PR DESCRIPTION
resolution events should not be filtered by filter_repeated

> On-call personnel may not receive resolve notifications due to this
filtering method. I believe this is a bad user experience which may lead
some people to mistrust Sensu as a monitoring and alerting system. I
think this is detrimental to our community
-- cwjohnston

https://github.com/sensu-plugins/sensu-plugin/pull/136#issuecomment-232738538

note, this is not in opposition to the goal of moving filtering out of sensu-handler.rb #136  it just fixes an issue prior to moving filtering out as well. 