### PR TITLE
update readme, indicate that settings access is common to all plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,6 @@ You can decide if you want to handle the event by overriding the
 built in method does some important filtering, so you probably want to
 call it with `super`).
 
-Sensu's configuration settings are available with the `settings` method
-(they will be loaded on first use). We recommend you put your settings in a
-JSON file in `/etc/sensu/conf.d`, with a unique top-level key, like:
-
-```
-{
-  "mycheck": {
-    "foo": true
-  }
-}
-```
-
 ## Mutator
 
 For your own mutator, subclass `Sensu::Mutator`. It looks much like
@@ -134,18 +122,6 @@ checks and metrics; Your class should implement `mutate`. The instance variable
 the mutator will abort. Output to stdout will then be piped through to the
 handler.  As described in the docs if a mutator fails to run the event will
 not be handled.
-
-Sensu's configuration settings are available with the `settings` method
-(they will be loaded on first use). We recommend you put your settings in a
-JSON file in `/etc/sensu/conf.d`, with a unique top-level key, like:
-
-```
-{
-  "mymutator": {
-    "foo": true
-  }
-}
-```
 
 The example mutator found [here](https://sensuapp.org/docs/latest/mutators) will
 look like so:
@@ -159,6 +135,31 @@ class MyMutator < Sensu::Mutator
     @event.merge!(:mutated => true)
   end
 
+end
+```
+
+## Plugin settings
+
+Whether you are writing a check, handler or mutator, Sensu's configuration
+settings are available with the `settings` method (loaded automatically
+when the plugin runs). We recommend you put your custom plugin settings
+in a JSON file in `/etc/sensu/conf.d`, with a unique top-level key,
+e.g. `my_custom_plugin`:
+
+```
+{
+  "my_custom_plugin": {
+    "foo": true,
+    "bar": false
+  }
+}
+```
+
+And access them in your plugin like so:
+
+```ruby
+def foo_enabled?
+  settings['my_custom_plugin']['foo']
 end
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update readme to be less repetitive and more explicit when describing the suggested method of  implementing plugin settings in Sensu configuration.

## Motivation and Context

Motivated by #140 , closes #140 

## How Has This Been Tested?

Change tested by reading it aloud to my rubber duck.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

