### PR TITLE
update changelog to cover deprecation of event filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Important
+- Filtering of events is now deprecated in `Sensu::Handler` and will be removed in a future release. See [this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html) for more detail.
+
 ### Changed
+- Warnings are now visible in handler output when deprecated event filtering is used, as it is by default. (#139 via @cwjohnston)
+- Filtering of events can now be disabled on a per-check basis by setting value of custom attribute `deprecated_filtering_enabled` to `false` (#139 via @cwjohnston)
+- Filtering of events based on occurrences can now be disabled on a per-check basis by setting value of custom attribute `deprecated_occurrence_filtering_enabled` to `false`  (#139 via @cwjohnston)
 - The `deep_merge` implementation has changed to mirror that of Sensu Core (#123 via @amdprophet):
 
  > Previously, if there were two conflicting data types in the same namespace (e.g. a Hash in one file, and an Array in another), sensu-plugin would throw an exception. It will now only use whatever loaded first, which is how Sensu Core handles this problem.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ You can decide if you want to handle the event by overriding the
 built in method does some important filtering, so you probably want to
 call it with `super`).
 
+### Important
+
+Filtering of events is now deprecated in `Sensu::Handler` and will be removed
+in a future release. See [this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html)
+for more detail.
+
 ## Mutator
 
 For your own mutator, subclass `Sensu::Mutator`. It looks much like


### PR DESCRIPTION
## Description
Update changelog.md to reflect changes related to deprecation of event filtering in sensu-plugin. 

## Motivation and Context
See https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html for more details on that deprecation.

## How Has This Been Tested?
Looks good in my browser

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
N/A
