### PR TITLE
Empty string dependancies break sensu-handler.rb

### DIFF
--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -209,9 +209,7 @@ module Sensu
         if @event['check']['dependencies'].is_a?(Array)
           @event['check']['dependencies'].each do |dependency|
             begin
-              if(dependency == "")
-                next
-              end
+              next if dependency.empty?
               Timeout.timeout(2) do
                 check, client = dependency.split('/').reverse
                 if event_exists?(client || @event['client']['name'], check)

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -209,6 +209,9 @@ module Sensu
         if @event['check']['dependencies'].is_a?(Array)
           @event['check']['dependencies'].each do |dependency|
             begin
+              if(dependency == "")
+                next
+              end
               Timeout.timeout(2) do
                 check, client = dependency.split('/').reverse
                 if event_exists?(client || @event['client']['name'], check)

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -209,7 +209,7 @@ module Sensu
         if @event['check']['dependencies'].is_a?(Array)
           @event['check']['dependencies'].each do |dependency|
             begin
-              next if dependency.empty?
+              next if dependency.to_s.empty?
               Timeout.timeout(2) do
                 check, client = dependency.split('/').reverse
                 if event_exists?(client || @event['client']['name'], check)


### PR DESCRIPTION
sensu-handler.rb breaks if one of the dependencies for a check is empty string. 
This probably shouldn't happen.
Check for empty string and don't try and parse that line.