### PR TITLE
pin json dependency at < 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Actually fix dependency loading problems in Ruby 1.9 environments by changing 'json' dependency from `<= 2.0.0` to `< 2.0.0`.
+
 ## [v1.4.0] - 2016-07-20
 
 ### Important

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*.rb']
   s.test_files    = Dir['test/*.rb']
 
-  s.add_dependency('json',       '<= 2.0.0')
+  s.add_dependency('json',       '< 2.0.0')
   s.add_dependency('mixlib-cli', '>= 1.5.0')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adjusting this dependency again to help those installing on Ruby < 2.0.

Per the commit message, 229702db7ac98294bd2ae3b2b3195c1ce8f05438 was intended
to pin json at < 2.0.0 but the actual change pinned it at <= 2.0.0 which
does not solve the issue raised in #138.

## Motivation and Context

Attempting to address problem described in #138. Specifically, fixing errors encountered when trying to install sensu-plugin on Ruby < 2.0 without a satisfactory version of json gem already installed.

Closes #148 

## How Has This Been Tested?

It has not been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats