### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [v1.4.1] - 2016-08-03
 
 ### Changed
-- Actually fix dependency loading problems in Ruby 1.9 environments by changing 'json' dependency from `<= 2.0.0` to `< 2.0.0`.
+- Actually fix dependency loading problems in Ruby 1.9 environments by changing 'json' dependency from `<= 2.0.0` to `< 2.0.0`. (#149 via @cwjohnston)
 
 ## [v1.4.0] - 2016-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Changed
 
+## [v1.4.1] - 2016-08-03
+
+### Changed
 - Actually fix dependency loading problems in Ruby 1.9 environments by changing 'json' dependency from `<= 2.0.0` to `< 2.0.0`.
 
 ## [v1.4.0] - 2016-07-20
@@ -64,7 +66,8 @@ The changes in earlier releases are not fully documented but comparison links ar
 * [v0.1.1]
 * [v0.1.0]
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.1...HEAD
+[v1.4.1]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.0...v1.4.1
 [v1.4.0]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.3.0...v1.4.0
 [v1.3.0]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.2.0...v1.3.0
 [v1.2.0]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.1.0...v1.2.0

--- a/lib/sensu-plugin.rb
+++ b/lib/sensu-plugin.rb
@@ -1,6 +1,6 @@
 module Sensu
   module Plugin
-    VERSION = "1.4.0"
+    VERSION = "1.4.1"
     EXIT_CODES = {
       'OK'       => 0,
       'WARNING'  => 1,


### PR DESCRIPTION

## Description
Release 1.4.1

## Motivation and Context
Corrects pin on `json` to be `< 2.0.0` per the original intent of #138.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)