### PR TITLE
Fix incorrect attribute reference in CHANGELOG, mention in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Warnings are now visible in handler output when deprecated event filtering is used, as it is by default. (#139 via @cwjohnston)
-- Filtering of events can now be disabled on a per-check basis by setting value of custom attribute `deprecated_filtering_enabled` to `false` (#139 via @cwjohnston)
-- Filtering of events based on occurrences can now be disabled on a per-check basis by setting value of custom attribute `deprecated_occurrence_filtering_enabled` to `false`  (#139 via @cwjohnston)
+- Filtering of events can now be disabled on a per-check basis by setting value of custom attribute `enable_deprecated_filtering` to `false` (#139 via @cwjohnston)
+- Filtering of events based on occurrences can now be disabled on a per-check basis by setting value of custom attribute `enable_deprecated_occurrence_filtering` to `false`  (#139 via @cwjohnston)
 - The `deep_merge` implementation has changed to mirror that of Sensu Core (#123 via @amdprophet):
 
  > Previously, if there were two conflicting data types in the same namespace (e.g. a Hash in one file, and an Array in another), sensu-plugin would throw an exception. It will now only use whatever loaded first, which is how Sensu Core handles this problem.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Filtering of events is now deprecated in `Sensu::Handler` and will be removed
 in a future release. See [this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html)
 for more detail.
 
+Event filtering in this library may be disabled on a per-check basis by setting
+the value of the check's `enable_deprecated_filtering` attribute to `false`.
+
 ## Mutator
 
 For your own mutator, subclass `Sensu::Mutator`. It looks much like


### PR DESCRIPTION
## Description

Fixing incorrectly named attributes in changelog

* `deprecated_filtering_enabled` should be `enable_deprecated_filtering`
* `deprecated_occurrence_filtering_enabled` should be `enable_deprecated_occurrence_filtering`

## Motivation and Context

As documented in #152, the changelog incorrectly names the attributes used for explicitly disabling the deprecated filtering behaviors.

## How Has This Been Tested?

No functional changes, updates are to documentation only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

None