### PR TITLE
[handler] converting URI to string before making api request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fixed an incompatability with Ruby 1.9 introduced in Sensu::Handler api_request circa sensu-plugin 1.3.0
+
 ## [v1.4.2] - 2016-08-08
 
 - Fixed a condition in which empty strings in check `dependencies` attribute values would cause an exception. (#147 via @rs-mrichmond)

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -133,7 +133,7 @@ module Sensu
       end
       domain = api_settings['host'].start_with?('http') ? api_settings['host'] : 'http://' + api_settings['host']
       uri = URI("#{domain}:#{api_settings['port']}#{path}")
-      req = net_http_req_class(method).new(uri)
+      req = net_http_req_class(method).new(uri.to_s)
       if api_settings['user'] && api_settings['password']
         req.basic_auth(api_settings['user'], api_settings['password'])
       end


### PR DESCRIPTION
## Description

In order to restore compatibility with Ruby 1.9, this change ensures the URI::HTTP object `uri` is converted to a string when passing as an argument to Net::HTTP.

## Motivation and Context

Although we concede that Ruby 1.9 is way past EOL, sensu-plugin is expected to retain compatibility with Ruby 1.9 until sensu-plugin version 2.0 is released.

Closes #154

## How Has This Been Tested?

Tested the change manually in REPL on Ruby 1.9.3-p551 and 2.3.1.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

None.