### PR TITLE
[handler] use plural form API endpoint in event_exists? method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Fixed an incompatability with Ruby 1.9 introduced in Sensu::Handler api_request circa sensu-plugin 1.3.0
+- Fixed Sensu::Handler check dependency filtering by using plural form `events` API endpoint, instead of singular-form `event`.
 
 ## [v1.4.2] - 2016-08-08
 

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -201,7 +201,7 @@ module Sensu
     end
 
     def event_exists?(client, check)
-      api_request(:GET, '/event/' + client + '/' + check).code == '200'
+      api_request(:GET, '/events/' + client + '/' + check).code == '200'
     end
 
     def filter_dependencies


### PR DESCRIPTION
## Description

This pull request changes the Sensu API endpoint used by `Sensu::Handler.event_exists?` from the singular form `event` to the plural form `events`.

## Motivation and Context

Sensu::Handler's `event_exists?` method uses the singular form of the `events` API. The plural form was added in Sensu 0.9, and the singular form was [removed in Sensu 0.25.0](https://github.com/sensu/sensu/blob/master/CHANGELOG.md#0250---2016-06-13).

Because the singular form was removed, `event_exists?` will always return `false`, effectively breaking the now-deprecated check dependency filtering in this library.

## How Has This Been Tested?

It has not been tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

* Breaks `filter_dependencies` for versions of Sensu prior to 0.9.
