### PR TITLE
[utils] only read from ENV['SENSU_LOADED_TEMPFILE'] if the file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Fixed an incompatability with Ruby 1.9 introduced in Sensu::Handler api_request circa sensu-plugin 1.3.0
+- Fixed an incompatibility with Ruby 1.9 introduced in Sensu::Handler api_request circa sensu-plugin 1.3.0
 - Fixed Sensu::Handler check dependency filtering by using plural form `events` API endpoint, instead of singular-form `event`.
+- Fixed a condition where `config_files` method may attempt to read from a non-existent file.
 
 ## [v1.4.2] - 2016-08-08
 

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -5,7 +5,7 @@ module Sensu
     module Utils
 
       def config_files
-        if ENV['SENSU_LOADED_TEMPFILE']
+        if ENV['SENSU_LOADED_TEMPFILE'] && File.file?(ENV['SENSU_LOADED_TEMPFILE'])
           IO.read(ENV['SENSU_LOADED_TEMPFILE']).split(':')
         elsif ENV['SENSU_CONFIG_FILES']
           ENV['SENSU_CONFIG_FILES'].split(':')


### PR DESCRIPTION
## Description

This change adds a condition to the `config_files` method, ensuring that the file 
described by `ENV['SENSU_LOADED_TEMPFILE']` exists on disk before attempting
to read from that file.

This change is proposed as an alternative to #115, as that PR includes additional logic which I believe will never work as intended.

## Motivation and Context

Because the value of `ENV['SENSU_LOADED_TEMPFILE']` may point to a file under /tmp
or another temporary directory, we should avoid errors by validating that a file exists at 
that path before trying to read from it.

Closes #115

## How Has This Been Tested?

Existing tests pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

None.