### PR TITLE
Fix issue 160: regression on sensu-handler.rb, introduced with Ruby 1.9.0 compatibility fix in 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+- Fixed an incompatibility with later Ruby versions introduced with the Ruby 1.9 fix in the Sensu::Handler, introduced in 1.4.3 (#155)
+
 ## [v1.4.3] - 2016-10-04
 
 - Fixed an incompatibility with Ruby 1.9 introduced in Sensu::Handler api_request circa sensu-plugin 1.3.0

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -133,7 +133,11 @@ module Sensu
       end
       domain = api_settings['host'].start_with?('http') ? api_settings['host'] : 'http://' + api_settings['host']
       uri = URI("#{domain}:#{api_settings['port']}#{path}")
-      req = net_http_req_class(method).new(uri.to_s)
+      if RUBY_VERSION > '1.9'
+        req = net_http_req_class(method).new(uri)
+      else
+        req = net_http_req_class(method).new(uri.to_s)
+      end
       if api_settings['user'] && api_settings['password']
         req.basic_auth(api_settings['user'], api_settings['password'])
       end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a regression in the sensu-handler.rb, which breaks calls to the sensu API in version 1.4.3. 
## Description

<!--- Describe your changes in detail -->

The regression was caused by a previous commit which fixed a bug in Ruby 1.9 [sensu-handler.rb, line 136: changed 'uri' to 'uri.to_s']. This fix commit simply wraps the `uri =` in an `if RUBY_VERSION > 1.9` check before deciding which method to use.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

sensu-plugins 1.4.3 is currently broken on newer Ruby versions.

<!--- If it fixes an open issue, please link to the issue here. -->

The issue this fixes is: https://github.com/sensu-plugins/sensu-plugin/issues/160
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

I am running this fork in a test datacenter on 3x sensu servers, and it fixes the regression.
I have not tested this on any older Ruby versions, but it's a simple 'if' statement.

<!--- Include details of your testing environment, and the tests you ran to -->

Versions used in test:
Ruby: 2.3.0
Sensu: 0.26.5
sensu-plugin: 1.4.3 (with this patch)

<!--- see how your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
## Known Caveats
