### PR TITLE
Fix regression in Sensu::Handler api_request under Ruby >= 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fixed a regression in Sensu::Handler `api_request` method, introduced in
+  v1.4.3, which broke silence stashes and check dependencies on Ruby 2.x.
+
 ## [v1.4.3] - 2016-10-04
 
 - Fixed an incompatibility with Ruby 1.9 introduced in Sensu::Handler api_request circa sensu-plugin 1.3.0

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -133,7 +133,7 @@ module Sensu
       end
       domain = api_settings['host'].start_with?('http') ? api_settings['host'] : 'http://' + api_settings['host']
       uri = URI("#{domain}:#{api_settings['port']}#{path}")
-      req = net_http_req_class(method).new(uri.to_s)
+      req = net_http_req_class(method).new(uri.path)
       if api_settings['user'] && api_settings['password']
         req.basic_auth(api_settings['user'], api_settings['password'])
       end


### PR DESCRIPTION
## Description

In #155 we attempted to address incompatibility with Ruby 1.9.x and instead introduced a regression which broke `api_request` method under Ruby 2.x. This change is intended to correct a regression introduced in #155.

## Motivation and Context

Comparing the arguments for `Net::HTTPGenericRequest` on
[1.9.1](https://ruby-doc.org/stdlib-1.9.1/libdoc/net/http/rdoc/Net/HTTPGenericRequest.html) vs [2.3.0](https://ruby-doc.org/stdlib-2.3.0/libdoc/net/http/rdoc/Net/HTTPGenericRequest.html), I see that 1.9.1 expects argument `path` where as 2.3.0 takes 
`uri_or_path` argument. If the `uri_or_path` is not a `URI` object, 
it is treated as the path.

I believe we can unconditionally pass the value of  `uri.path` to
`net_http_req_class(method).new` on both ruby 1.9 and 2.x, as the hostname, port
and scheme are explicitly set when calling `Net::HTTP.start`.

Closes https://github.com/sensu-plugins/sensu-plugins-sensu/issues/18
Closes https://github.com/sensu-plugins/sensu-plugin/issues/160
Closes https://github.com/sensu-plugins/sensu-plugin/issues/161

## How Has This Been Tested?

In order to test this change I created an Ubuntu 16.04 VM and used the ruby-build and rbenv tools to configure two separate Ruby environments: 1.9.3-p551 and 2.3.3, respectively.

I configured a Sensu stack to process events submitted via the client's local socket and installed sensu-plugin 1.4.3 and a handler plugin in each of the aforementioned Ruby environments.

This enabled me to test this change with regard to handler accessing the API for check dependencies and silence stashes, both of which are working under both Rubies with this change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats