### PR TITLE
Add support for globally disabling deprecated filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added support for globally disabling deprecated filtering methods via the
+  `sensu_plugin` configuration scope. See README for example.
+
 ## [v1.4.4] - 2016-12-08
 
 - Fixed a regression in Sensu::Handler `api_request` method, introduced in

--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ Filtering of events is now deprecated in `Sensu::Handler` and will be removed
 in a future release. See [this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html)
 for more detail.
 
+Event filtering in this library may be globally disabled via the
+`sensu_plugin` configuration scope, e.g.:
+
+  ``` json
+  # /etc/sensu/conf.d/sensu_plugin.json
+  {
+    "sensu_plugin": {
+      "disable_deprecated_filtering": true
+    }
+  }
+  ```
+
 Event filtering in this library may be disabled on a per-check basis by setting
 the value of the check's `enable_deprecated_filtering` attribute to `false`.
 

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -42,20 +42,38 @@ module Sensu
       end
     end
 
-    # Evaluates whether the event should be processed by any of the filter methods in
-    # this library. Defaults to true (i.e. deprecated filters are run by default.)
+    # Evaluates whether deprecated filtering is explicitly disabled
+    # via global Sensu configuration. Defaults to false,
+    # i.e. deprecated filters are run by default.
+    #
+    # @return [TrueClass, FalseClass]
+    def deprecated_filtering_globally_disabled?
+      global_settings = settings.fetch('sensu_plugin', {})
+      global_settings['disable_deprecated_filtering'].to_s == "true"
+    end
+
+    # Evaluates whether the event should be processed by any of the
+    # filter methods in this library. Defaults to true,
+    # i.e. deprecated filters are run by default.
     #
     # @return [TrueClass, FalseClass]
     def deprecated_filtering_enabled?
-      @event['check']['enable_deprecated_filtering'].nil? || @event['check']['enable_deprecated_filtering'] == true
+      if deprecated_filtering_globally_disabled?
+        return false
+      else
+        @event['check']['enable_deprecated_filtering'].nil? || \
+        @event['check']['enable_deprecated_filtering'].to_s == "true"
+      end
     end
 
-    # Evaluates whether the event should be processed by the filter_repeated method. Defaults to true (i.e.
-    # filter_repeated will filter events by default)
+    # Evaluates whether the event should be processed by the
+    # filter_repeated method. Defaults to true, i.e. filter_repeated
+    # will filter events by default.
     #
     # @return [TrueClass, FalseClass]
     def deprecated_occurrence_filtering_enabled?
-      @event['check']['enable_deprecated_occurrence_filtering'].nil? || @event['check']['enable_deprecated_occurrence_filtering'] == true
+      @event['check']['enable_deprecated_occurrence_filtering'].nil? || \
+      @event['check']['enable_deprecated_occurrence_filtering'].to_s == "true"
     end
 
     # This works just like Plugin::CLI's autorun.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,14 @@ module SensuPluginTestHelper
     end
   end
 
+  def run_script_in_env_with_input(input, env, *args)
+    IO.popen(env, ([@script] + args).join(' '), 'r+') do |child|
+      child.puts input
+      child.close_write
+      child.read
+    end
+  end
+
   def fixture_path
     File.expand_path('../fixtures', __FILE__)
   end


### PR DESCRIPTION
## Description

Adds support for globally disabling deprecated filters by specifying

```
{ 
  "sensu_plugin": {
     "disable_deprecated_filtering": true
  }
}
```

## Motivation and Context

Closes #166 

Relates to #136 

## How Has This Been Tested?

Added unit test, tested pre-release build in local lab environment.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
