### PR TITLE
Release version 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v1.4.5] - 2017-03-07
+
 - Added support for globally disabling deprecated filtering methods via the
   `sensu_plugin` configuration scope. See README for example.
 
@@ -83,7 +85,8 @@ The changes in earlier releases are not fully documented but comparison links ar
 * [v0.1.1]
 * [v0.1.0]
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.4...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.5...HEAD
+[v1.4.5]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.4...v1.4.5
 [v1.4.4]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.3...v1.4.4
 [v1.4.3]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.2...v1.4.3
 [v1.4.2]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.1...v1.4.2

--- a/lib/sensu-plugin.rb
+++ b/lib/sensu-plugin.rb
@@ -1,6 +1,6 @@
 module Sensu
   module Plugin
-    VERSION = "1.4.4"
+    VERSION = "1.4.5"
     EXIT_CODES = {
       'OK'       => 0,
       'WARNING'  => 1,


### PR DESCRIPTION
## Description

Update version string and changelog to release 1.4.5

## Motivation and Context

Release includes feature added in #167, enabling Sensu operators to globally disable this library's deprecated filter methods.

## How Has This Been Tested?

Manually tested a release candidate build in a lab environment.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)