### PR TITLE
Drop support for Ruby < 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Plugins now exit with status `3` (unknown) when encountering an
   exception or being run with bad arguments.
+- Removed support for Ruby 1.9 and earlier.
 
 ## [v1.4.5] - 2017-03-07
 

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -1,19 +1,20 @@
 require File.expand_path(File.dirname(__FILE__)) + '/lib/sensu-plugin'
 
 Gem::Specification.new do |s|
-  s.name          = 'sensu-plugin'
-  s.version       = Sensu::Plugin::VERSION
-  s.platform      = Gem::Platform::RUBY
-  s.authors       = ['Decklin Foster', 'Sean Porter']
-  s.email         = ['decklin@red-bean.com', 'portertech@gmail.com']
-  s.homepage      = 'https://github.com/sensu-plugins/sensu-plugin'
-  s.summary       = 'Sensu Plugins'
-  s.description   = 'Plugins and helper libraries for Sensu, a monitoring framework'
-  s.license       = 'MIT'
-  s.has_rdoc      = false
-  s.require_paths = ['lib']
-  s.files         = Dir['lib/**/*.rb']
-  s.test_files    = Dir['test/*.rb']
+  s.name                  = 'sensu-plugin'
+  s.version               = Sensu::Plugin::VERSION
+  s.platform              = Gem::Platform::RUBY
+  s.authors               = ['Decklin Foster', 'Sean Porter']
+  s.email                 = ['decklin@red-bean.com', 'portertech@gmail.com']
+  s.homepage              = 'https://github.com/sensu-plugins/sensu-plugin'
+  s.summary               = 'Sensu Plugins'
+  s.description           = 'Plugins and helper libraries for Sensu, a monitoring framework'
+  s.license               = 'MIT'
+  s.has_rdoc              = false
+  s.require_paths         = ['lib']
+  s.files                 = Dir['lib/**/*.rb']
+  s.test_files            = Dir['test/*.rb']
+  s.required_ruby_version = '~> 2.0'
 
   s.add_dependency('json',       '< 2.0.0')
   s.add_dependency('mixlib-cli', '>= 1.5.0')

--- a/test/external/handle-argument
+++ b/test/external/handle-argument
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 
 class Argument < Sensu::Handler

--- a/test/external/handle-filter
+++ b/test/external/handle-filter
@@ -1,7 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
-
 require 'sensu-handler'
 
 class Filter < Sensu::Handler

--- a/test/external/handle-helpers
+++ b/test/external/handle-helpers
@@ -1,7 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
-
 require 'sensu-handler'
 
 class Helpers < Sensu::Handler

--- a/test/external/handle-nofilter
+++ b/test/external/handle-nofilter
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 
 class NoFilter < Sensu::Handler

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-gem 'minitest' if RUBY_VERSION < '1.9.0'
 require 'minitest/autorun'
 
 module SensuPluginTestHelper


### PR DESCRIPTION
## Description

Drop support for Ruby < 2.0 by specifying `required_ruby_version = '~> 2.0'`  in the gemspec.

## Motivation and Context

Ruby 1.9 is EOL.

## How Has This Been Tested?

Specs pass.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

Requires a major version bump in order to follow SemVer.