### PR TITLE
Disable deprecated filters by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Plugins now exit with status `3` (unknown) when encountering an
   exception or being run with bad arguments.
 - Removed support for Ruby 1.9 and earlier.
+- Deprecated filtering methods in this library are now disabled by default.
 
 ## [v1.4.5] - 2017-03-07
 

--- a/README.md
+++ b/README.md
@@ -114,26 +114,18 @@ You can decide if you want to handle the event by overriding the
 built in method does some important filtering, so you probably want to
 call it with `super`).
 
-### Important
+### Important!
 
-Filtering of events is now deprecated in `Sensu::Handler` and will be removed
-in a future release. See [this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html)
+Filtering of events is now deprecated in `Sensu::Handler` and disabled
+by default as of version 2.0.
+
+Event filtering in this library may be enabled on a per-check basis by setting
+the value of the check's `enable_deprecated_filtering` attribute to `true`.
+
+These built-in filters will be removed in a future release. See
+[this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html)
 for more detail.
 
-Event filtering in this library may be globally disabled via the
-`sensu_plugin` configuration scope, e.g.:
-
-  ``` json
-  # /etc/sensu/conf.d/sensu_plugin.json
-  {
-    "sensu_plugin": {
-      "disable_deprecated_filtering": true
-    }
-  }
-  ```
-
-Event filtering in this library may be disabled on a per-check basis by setting
-the value of the check's `enable_deprecated_filtering` attribute to `false`.
 
 ## Mutator
 

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -42,28 +42,13 @@ module Sensu
       end
     end
 
-    # Evaluates whether deprecated filtering is explicitly disabled
-    # via global Sensu configuration. Defaults to false,
-    # i.e. deprecated filters are run by default.
-    #
-    # @return [TrueClass, FalseClass]
-    def deprecated_filtering_globally_disabled?
-      global_settings = settings.fetch('sensu_plugin', {})
-      global_settings['disable_deprecated_filtering'].to_s == "true"
-    end
-
     # Evaluates whether the event should be processed by any of the
     # filter methods in this library. Defaults to true,
     # i.e. deprecated filters are run by default.
     #
     # @return [TrueClass, FalseClass]
     def deprecated_filtering_enabled?
-      if deprecated_filtering_globally_disabled?
-        return false
-      else
-        @event['check']['enable_deprecated_filtering'].nil? || \
-        @event['check']['enable_deprecated_filtering'].to_s == "true"
-      end
+      @event['check']['enable_deprecated_filtering'].to_s == "true"
     end
 
     # Evaluates whether the event should be processed by the

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -48,7 +48,7 @@ module Sensu
     #
     # @return [TrueClass, FalseClass]
     def deprecated_filtering_enabled?
-      @event['check']['enable_deprecated_filtering'].to_s == "true"
+      @event['check'].fetch('enable_deprecated_filtering', false).to_s == "true"
     end
 
     # Evaluates whether the event should be processed by the
@@ -57,8 +57,7 @@ module Sensu
     #
     # @return [TrueClass, FalseClass]
     def deprecated_occurrence_filtering_enabled?
-      @event['check']['enable_deprecated_occurrence_filtering'].nil? || \
-      @event['check']['enable_deprecated_occurrence_filtering'].to_s == "true"
+      @event['check'].fetch('enable_deprecated_occurrence_filtering', false).to_s == "true"
     end
 
     # This works just like Plugin::CLI's autorun.

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -11,7 +11,11 @@ class TestFilterExternal < MiniTest::Test
   def test_create_not_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 1,
       'action' => 'create'
     }
@@ -23,7 +27,11 @@ class TestFilterExternal < MiniTest::Test
   def test_create_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 2,
       'action' => 'create'
     }
@@ -35,7 +43,11 @@ class TestFilterExternal < MiniTest::Test
   def test_resolve_not_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 1,
       'action' => 'resolve'
     }
@@ -47,7 +59,11 @@ class TestFilterExternal < MiniTest::Test
   def test_resolve_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 2,
       'action' => 'resolve'
     }
@@ -59,7 +75,10 @@ class TestFilterExternal < MiniTest::Test
   def test_refresh_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test' },
+      'check' => {
+        'name' => 'test',
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 61,
       'action' => 'create'
     }
@@ -71,7 +90,10 @@ class TestFilterExternal < MiniTest::Test
   def test_refresh_not_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test' },
+      'check' => {
+        'name' => 'test',
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 60,
       'action' => 'create'
     }
@@ -107,7 +129,11 @@ class TestFilterExternal < MiniTest::Test
   def test_dependency_event_exists
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'dependencies' => ['foo', 'bar'] },
+      'check' => {
+        'name' => 'test',
+        'dependencies' => ['foo', 'bar'],
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 1
     }
     output = run_script_with_input(JSON.generate(event))
@@ -119,7 +145,7 @@ class TestFilterExternal < MiniTest::Test
     'warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
   end
 
-  def test_filter_deprecation_warning_exists_by_default
+  def test_filter_deprecation_warning_is_not_present_by_default
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test', 'refresh' => 30 },
@@ -128,7 +154,7 @@ class TestFilterExternal < MiniTest::Test
     }
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
-    assert_match(/#{filter_deprecation_string}/, output)
+    refute_match(/#{filter_deprecation_string}/, output)
   end
 
   def test_filter_deprecation_warning_exists_when_explicitly_enabled
@@ -184,7 +210,7 @@ class TestFilterExternal < MiniTest::Test
     'warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
   end
 
-  def test_occurrence_filter_deprecation_warning_exists_by_default
+  def test_occurrence_filter_deprecation_warning_not_present_by_default
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test', 'refresh' => 30 },
@@ -193,15 +219,16 @@ class TestFilterExternal < MiniTest::Test
     }
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
-    assert_match(/#{occurrence_filter_deprecation_string}/, output)
+    refute_match(/#{occurrence_filter_deprecation_string}/, output)
   end
 
-  def test_occurrence_filter_deprecation_warning_exists_when_explicitly_enabled
+  def test_occurrence_filter_deprecation_warning_present_when_explicitly_enabled
     event = {
       'client' => { 'name' => 'test' },
       'check' => {
         'name' => 'test',
         'refresh' => 30,
+        'enable_deprecated_filtering' => true,
         'enable_deprecated_occurrence_filtering' => true
       },
       'occurrences' => 60,
@@ -212,12 +239,13 @@ class TestFilterExternal < MiniTest::Test
     assert_match(/#{occurrence_filter_deprecation_string}/, output)
   end
 
-  def test_occurrence_filter_deprecation_warning_does_not_exist_when_explicitly_disabled
+  def test_occurrence_filter_deprecation_warning_not_present_when_explicitly_disabled
     event = {
       'client' => { 'name' => 'test' },
       'check' => {
         'name' => 'unfiltered test',
         'refresh' => 30,
+        'enable_deprecated_filtering' => true,
         'enable_deprecated_occurrence_filtering' => false
       },
       'occurrences' => 60,

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -14,7 +14,8 @@ class TestFilterExternal < MiniTest::Test
       'check' => {
         'name' => 'test',
         'occurrences' => 2,
-        'enable_deprecated_filtering' => true
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
       },
       'occurrences' => 1,
       'action' => 'create'
@@ -30,7 +31,8 @@ class TestFilterExternal < MiniTest::Test
       'check' => {
         'name' => 'test',
         'occurrences' => 2,
-        'enable_deprecated_filtering' => true
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
       },
       'occurrences' => 2,
       'action' => 'create'
@@ -46,7 +48,8 @@ class TestFilterExternal < MiniTest::Test
       'check' => {
         'name' => 'test',
         'occurrences' => 2,
-        'enable_deprecated_filtering' => true
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
       },
       'occurrences' => 1,
       'action' => 'resolve'
@@ -77,7 +80,8 @@ class TestFilterExternal < MiniTest::Test
       'client' => { 'name' => 'test' },
       'check' => {
         'name' => 'test',
-        'enable_deprecated_filtering' => true
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
       },
       'occurrences' => 61,
       'action' => 'create'
@@ -92,7 +96,8 @@ class TestFilterExternal < MiniTest::Test
       'client' => { 'name' => 'test' },
       'check' => {
         'name' => 'test',
-        'enable_deprecated_filtering' => true
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
       },
       'occurrences' => 60,
       'action' => 'create'


### PR DESCRIPTION
## Description

- Remove logic for disabling deprecated filters via global override
- Update logic to ensure deprecated filters are disabled by default

## Motivation and Context

As described in #134, this change is part of a strategy to move event filtering out of this library and into Sensu Core.

## How Has This Been Tested?

Updated unit tests to test the new desired behavior.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

Requires a major version bump in order to follow SemVer.