### PR TITLE
Release 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.1
 before_install:
   - gem update bundler
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v2.0.0] - 2017-03-29
+
+IMPORTANT! This release includes the following potentially breaking changes:
+
 - Plugins now exit with status `3` (unknown) when encountering an
   exception or being run with bad arguments.
 - Removed support for Ruby 1.9 and earlier.
@@ -90,7 +94,8 @@ The changes in earlier releases are not fully documented but comparison links ar
 * [v0.1.1]
 * [v0.1.0]
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.5...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugin/compare/v2.0.0...HEAD
+[v2.0.0]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.5...v2.0.0
 [v1.4.5]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.4...v1.4.5
 [v1.4.4]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.3...v1.4.4
 [v1.4.3]: https://github.com/sensu-plugins/sensu-plugin/compare/v1.4.2...v1.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Plugins now exit with status `3` (unknown) when encountering an
   exception or being run with bad arguments.
+- Removed support for Ruby 1.9 and earlier.
 
 ## [v1.4.5] - 2017-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Plugins now exit with status `3` (unknown) when encountering an
   exception or being run with bad arguments.
 - Removed support for Ruby 1.9 and earlier.
+- Deprecated filtering methods in this library are now disabled by default.
 
 ## [v1.4.5] - 2017-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Plugins now exit with status `3` (unknown) when encountering an
+  exception or being run with bad arguments.
+
 ## [v1.4.5] - 2017-03-07
 
 - Added support for globally disabling deprecated filtering methods via the

--- a/README.md
+++ b/README.md
@@ -114,26 +114,18 @@ You can decide if you want to handle the event by overriding the
 built in method does some important filtering, so you probably want to
 call it with `super`).
 
-### Important
+### Important!
 
-Filtering of events is now deprecated in `Sensu::Handler` and will be removed
-in a future release. See [this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html)
+Filtering of events is now deprecated in `Sensu::Handler` and disabled
+by default as of version 2.0.
+
+Event filtering in this library may be enabled on a per-check basis by setting
+the value of the check's `enable_deprecated_filtering` attribute to `true`.
+
+These built-in filters will be removed in a future release. See
+[this blog post](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html)
 for more detail.
 
-Event filtering in this library may be globally disabled via the
-`sensu_plugin` configuration scope, e.g.:
-
-  ``` json
-  # /etc/sensu/conf.d/sensu_plugin.json
-  {
-    "sensu_plugin": {
-      "disable_deprecated_filtering": true
-    }
-  }
-  ```
-
-Event filtering in this library may be disabled on a per-check basis by setting
-the value of the check's `enable_deprecated_filtering` attribute to `false`.
 
 ## Mutator
 

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -42,28 +42,13 @@ module Sensu
       end
     end
 
-    # Evaluates whether deprecated filtering is explicitly disabled
-    # via global Sensu configuration. Defaults to false,
-    # i.e. deprecated filters are run by default.
-    #
-    # @return [TrueClass, FalseClass]
-    def deprecated_filtering_globally_disabled?
-      global_settings = settings.fetch('sensu_plugin', {})
-      global_settings['disable_deprecated_filtering'].to_s == "true"
-    end
-
     # Evaluates whether the event should be processed by any of the
     # filter methods in this library. Defaults to true,
     # i.e. deprecated filters are run by default.
     #
     # @return [TrueClass, FalseClass]
     def deprecated_filtering_enabled?
-      if deprecated_filtering_globally_disabled?
-        return false
-      else
-        @event['check']['enable_deprecated_filtering'].nil? || \
-        @event['check']['enable_deprecated_filtering'].to_s == "true"
-      end
+      @event['check'].fetch('enable_deprecated_filtering', false).to_s == "true"
     end
 
     # Evaluates whether the event should be processed by the
@@ -72,8 +57,7 @@ module Sensu
     #
     # @return [TrueClass, FalseClass]
     def deprecated_occurrence_filtering_enabled?
-      @event['check']['enable_deprecated_occurrence_filtering'].nil? || \
-      @event['check']['enable_deprecated_occurrence_filtering'].to_s == "true"
+      @event['check'].fetch('enable_deprecated_occurrence_filtering', false).to_s == "true"
     end
 
     # This works just like Plugin::CLI's autorun.

--- a/lib/sensu-plugin.rb
+++ b/lib/sensu-plugin.rb
@@ -1,6 +1,6 @@
 module Sensu
   module Plugin
-    VERSION = "1.4.5"
+    VERSION = "2.0.0"
     EXIT_CODES = {
       'OK'       => 0,
       'WARNING'  => 1,

--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -60,11 +60,11 @@ module Sensu
             exit e.status
           rescue OptionParser::InvalidOption => e
             puts "Invalid check argument(s): #{e.message}, #{e.backtrace}"
-            exit 1
+            exit 3
           rescue Exception => e
             # This can't call check.critical, as the check may have failed to construct
             puts "Check failed to run: #{e.message}, #{e.backtrace}"
-            exit 2
+            exit 3
           end
           check.warning "Check did not exit! You should call an exit code method."
         end

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -1,19 +1,20 @@
 require File.expand_path(File.dirname(__FILE__)) + '/lib/sensu-plugin'
 
 Gem::Specification.new do |s|
-  s.name          = 'sensu-plugin'
-  s.version       = Sensu::Plugin::VERSION
-  s.platform      = Gem::Platform::RUBY
-  s.authors       = ['Decklin Foster', 'Sean Porter']
-  s.email         = ['decklin@red-bean.com', 'portertech@gmail.com']
-  s.homepage      = 'https://github.com/sensu-plugins/sensu-plugin'
-  s.summary       = 'Sensu Plugins'
-  s.description   = 'Plugins and helper libraries for Sensu, a monitoring framework'
-  s.license       = 'MIT'
-  s.has_rdoc      = false
-  s.require_paths = ['lib']
-  s.files         = Dir['lib/**/*.rb']
-  s.test_files    = Dir['test/*.rb']
+  s.name                  = 'sensu-plugin'
+  s.version               = Sensu::Plugin::VERSION
+  s.platform              = Gem::Platform::RUBY
+  s.authors               = ['Decklin Foster', 'Sean Porter']
+  s.email                 = ['decklin@red-bean.com', 'portertech@gmail.com']
+  s.homepage              = 'https://github.com/sensu-plugins/sensu-plugin'
+  s.summary               = 'Sensu Plugins'
+  s.description           = 'Plugins and helper libraries for Sensu, a monitoring framework'
+  s.license               = 'MIT'
+  s.has_rdoc              = false
+  s.require_paths         = ['lib']
+  s.files                 = Dir['lib/**/*.rb']
+  s.test_files            = Dir['test/*.rb']
+  s.required_ruby_version = '~> 2.0'
 
   s.add_dependency('json',       '< 2.0.0')
   s.add_dependency('mixlib-cli', '>= 1.5.0')

--- a/test/external/handle-argument
+++ b/test/external/handle-argument
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 
 class Argument < Sensu::Handler

--- a/test/external/handle-filter
+++ b/test/external/handle-filter
@@ -1,7 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
-
 require 'sensu-handler'
 
 class Filter < Sensu::Handler

--- a/test/external/handle-helpers
+++ b/test/external/handle-helpers
@@ -1,7 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
-
 require 'sensu-handler'
 
 class Helpers < Sensu::Handler

--- a/test/external/handle-nofilter
+++ b/test/external/handle-nofilter
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 
 class NoFilter < Sensu::Handler

--- a/test/external_check_test.rb
+++ b/test/external_check_test.rb
@@ -39,7 +39,7 @@ class TestCheckExternal < MiniTest::Test
 
   def test_exception
     output = run_script '-f'
-    assert $?.exitstatus == 2 && output.include?('failed')
+    assert $?.exitstatus == 3 && output.include?('failed')
   end
 
   def test_argv
@@ -49,7 +49,7 @@ class TestCheckExternal < MiniTest::Test
 
   def test_bad_commandline
     output = run_script '--doesnotexist'
-    assert $?.exitstatus == 1 && output.include?('doesnotexist') && output.include?('invalid option')
+    assert $?.exitstatus == 3 && output.include?('doesnotexist') && output.include?('invalid option')
   end
 
   def test_bad_require

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -11,7 +11,12 @@ class TestFilterExternal < MiniTest::Test
   def test_create_not_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
+      },
       'occurrences' => 1,
       'action' => 'create'
     }
@@ -23,7 +28,12 @@ class TestFilterExternal < MiniTest::Test
   def test_create_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
+      },
       'occurrences' => 2,
       'action' => 'create'
     }
@@ -35,7 +45,12 @@ class TestFilterExternal < MiniTest::Test
   def test_resolve_not_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
+      },
       'occurrences' => 1,
       'action' => 'resolve'
     }
@@ -47,7 +62,11 @@ class TestFilterExternal < MiniTest::Test
   def test_resolve_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'occurrences' => 2 },
+      'check' => {
+        'name' => 'test',
+        'occurrences' => 2,
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 2,
       'action' => 'resolve'
     }
@@ -59,7 +78,11 @@ class TestFilterExternal < MiniTest::Test
   def test_refresh_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test' },
+      'check' => {
+        'name' => 'test',
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
+      },
       'occurrences' => 61,
       'action' => 'create'
     }
@@ -71,7 +94,11 @@ class TestFilterExternal < MiniTest::Test
   def test_refresh_not_enough_occurrences
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test' },
+      'check' => {
+        'name' => 'test',
+        'enable_deprecated_filtering' => true,
+        'enable_deprecated_occurrence_filtering' => true
+      },
       'occurrences' => 60,
       'action' => 'create'
     }
@@ -107,7 +134,11 @@ class TestFilterExternal < MiniTest::Test
   def test_dependency_event_exists
     event = {
       'client' => { 'name' => 'test' },
-      'check' => { 'name' => 'test', 'dependencies' => ['foo', 'bar'] },
+      'check' => {
+        'name' => 'test',
+        'dependencies' => ['foo', 'bar'],
+        'enable_deprecated_filtering' => true
+      },
       'occurrences' => 1
     }
     output = run_script_with_input(JSON.generate(event))
@@ -119,7 +150,7 @@ class TestFilterExternal < MiniTest::Test
     'warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
   end
 
-  def test_filter_deprecation_warning_exists_by_default
+  def test_filter_deprecation_warning_is_not_present_by_default
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test', 'refresh' => 30 },
@@ -128,7 +159,7 @@ class TestFilterExternal < MiniTest::Test
     }
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
-    assert_match(/#{filter_deprecation_string}/, output)
+    refute_match(/#{filter_deprecation_string}/, output)
   end
 
   def test_filter_deprecation_warning_exists_when_explicitly_enabled
@@ -184,7 +215,7 @@ class TestFilterExternal < MiniTest::Test
     'warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin'
   end
 
-  def test_occurrence_filter_deprecation_warning_exists_by_default
+  def test_occurrence_filter_deprecation_warning_not_present_by_default
     event = {
       'client' => { 'name' => 'test' },
       'check' => { 'name' => 'test', 'refresh' => 30 },
@@ -193,15 +224,16 @@ class TestFilterExternal < MiniTest::Test
     }
     output = run_script_with_input(JSON.generate(event))
     assert_equal(0, $?.exitstatus)
-    assert_match(/#{occurrence_filter_deprecation_string}/, output)
+    refute_match(/#{occurrence_filter_deprecation_string}/, output)
   end
 
-  def test_occurrence_filter_deprecation_warning_exists_when_explicitly_enabled
+  def test_occurrence_filter_deprecation_warning_present_when_explicitly_enabled
     event = {
       'client' => { 'name' => 'test' },
       'check' => {
         'name' => 'test',
         'refresh' => 30,
+        'enable_deprecated_filtering' => true,
         'enable_deprecated_occurrence_filtering' => true
       },
       'occurrences' => 60,
@@ -212,12 +244,13 @@ class TestFilterExternal < MiniTest::Test
     assert_match(/#{occurrence_filter_deprecation_string}/, output)
   end
 
-  def test_occurrence_filter_deprecation_warning_does_not_exist_when_explicitly_disabled
+  def test_occurrence_filter_deprecation_warning_not_present_when_explicitly_disabled
     event = {
       'client' => { 'name' => 'test' },
       'check' => {
         'name' => 'unfiltered test',
         'refresh' => 30,
+        'enable_deprecated_filtering' => true,
         'enable_deprecated_occurrence_filtering' => false
       },
       'occurrences' => 60,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-gem 'minitest' if RUBY_VERSION < '1.9.0'
 require 'minitest/autorun'
 
 module SensuPluginTestHelper


### PR DESCRIPTION
## Description

Release new major version with breaking changes.

## Motivation and Context

Ship changes which disable built-in filter methods by default, as described in #134 

## How Has This Been Tested?

Gem artifact has been tested against updated handler plugin in my lab.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

Existing sensu-plugins projects will need dependencies on this project updated to `~> 2.0` or similar.
