### PR TITLE
Update json requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Update json module requirement to < 3.0.0
+
 ## [v2.0.0] - 2017-03-29
 
 IMPORTANT! This release includes the following potentially breaking changes:

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files            = Dir['test/*.rb']
   s.required_ruby_version = '~> 2.0'
 
-  s.add_dependency('json',       '< 2.0.0')
+  s.add_dependency('json',       '< 3.0.0')
   s.add_dependency('mixlib-cli', '>= 1.5.0')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
All tests pass, but using simplecov doesn't give me a lot of
confidence in the level of code coverage, especially the code
that might be parsing and usin JSON.

Update json required version.

## Description
Bump json requirement to < 3.0.0

## Motivation and Context
The requirement to use json < 2 conflicts with rest-client which can use versions later. Depending on which gets require'd first, ruby will throw an error saying it can't resolve the dependency.

## How Has This Been Tested?
I ran rake.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
