### PR TITLE
Helper method to convert boolean strings to integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Added cast_bool_values_int helper method to convert boolean values to integers
 
 ## [v2.0.1] - 2017-04-28
 

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -64,9 +64,9 @@ module Sensu
 
       def cast_bool_values_int(value)
         case value
-        when 'true'
+        when 'true', true
           1
-        when 'false'
+        when 'false', false
           0
         else
           value

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -61,6 +61,17 @@ module Sensu
         end
         merged
       end
+
+      def cast_bool_values_int(value)
+        case value
+        when true
+          1
+        when false
+          0
+        else
+          value
+        end
+      end
     end
   end
 end

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -64,9 +64,9 @@ module Sensu
 
       def cast_bool_values_int(value)
         case value
-        when true
+        when 'true'
           1
-        when false
+        when 'false'
           0
         else
           value

--- a/test/cast_bool_value_test.rb
+++ b/test/cast_bool_value_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+require 'sensu-plugin/utils'
+
+class TestCastBoolInt < MiniTest::Test
+  include SensuPluginTestHelper
+  include Sensu::Plugin::Utils
+
+  def test_integer
+    assert_equal 567.89, cast_bool_values_int(567.89)
+  end
+
+  def test_false_boolean
+    assert_equal 0, cast_bool_values_int(false)
+  end
+
+  def test_true_boolean
+    assert_equal 1, cast_bool_values_int(true)
+  end
+
+  def test_false_string
+    assert_equal 0, cast_bool_values_int('false')
+  end
+
+  def test_true_string
+    assert_equal 1, cast_bool_values_int('true')
+  end
+
+  def test_arbirtrary_string
+    assert_equal 'foo', cast_bool_values_int('foo')
+  end
+end


### PR DESCRIPTION
Additional helper method `cast_bool_values_int` to convert a provided boolean string to respective integer value.

## Description
This method accepts a single value, converting a true or false string to 1 or 0 respectively.
Any other values will just be returned.

## Motivation and Context
In certain metric collection plugins, metrics are occasionally generated with true/false values rather than integers. Certain TSDB's will not accept boolean values and instead expect integer equivalents (i.e. Graphite, true = 1, false = 0). See https://github.com/sensu-plugins/sensu-plugins-elasticsearch/issues/49 for reference

This helper method allows, where applicable, these values to be converted into integers so they can be successfully ingested by those TSDB's.

## How Has This Been Tested?
Tested new method in local environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
