### PR TITLE
Add new output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added subclass for InfluxDB output
+- Added subclass for DogStatsD output
 
 ## [2.2.0] - 2017-08-15
 - Added rubocop test to the Rakefile (@luisdavim)

--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -17,6 +17,14 @@ module Sensu
         end
 
         class Graphite < Sensu::Plugin::CLI
+          # Outputs metrics using the Statsd datagram format
+          #
+          # @param args [Array<String, Int>] list of arguments
+          # @note the argument order should be:
+          #   `metric_path`: Mandatory, name for the metric,
+          #   `value`: Mandatory, metric value
+          #   `timestamp`: Optional, unix timestamp, defaults to current time
+          # @return [String] formated metric data
           def output(*args)
             return if args.empty?
             if args[0].is_a?(Exception) || args[1].nil?
@@ -29,12 +37,70 @@ module Sensu
         end
 
         class Statsd < Sensu::Plugin::CLI
+          # Outputs metrics using the Statsd datagram format
+          #
+          # @param args [Array<String, Int>] list of arguments
+          # @note the argument order should be:
+          #   `metric_name`: Mandatory, name for the metric,
+          #   `value`: Mandatory, metric value
+          #   `type`: Optional, metric type- `c` for counter, `g` for gauge, `ms` for timer, `s` for set
+          # @return [String] formated metric data
           def output(*args)
+            return if args.empty?
             if args[0].is_a?(Exception) || args[1].nil?
               puts args[0].to_s
             else
               type = args[2] || 'kv'
               puts [args[0..1].join(':'), type].join('|')
+            end
+          end
+        end
+
+        class Dogstatsd < Sensu::Plugin::CLI
+          # Outputs metrics using the DogStatsd datagram format
+          #
+          # @param args [Array<String, Int>] list of arguments
+          # @note the argument order should be:
+          #   `metric_name`: Mandatory, name for the metric,
+          #   `value`: Mandatory, metric value
+          #   `type`: Optional, metric type- `c` for counter, `g` for gauge, `ms` for timer, `h` for histogram, `s` for set
+          #   `tags`: Optional, a comma separated key:value string `tag1:value1,tag2:value2`
+          # @return [String] formated metric data
+          def output(*args)
+            return if args.empty?
+            if args[0].is_a?(Exception) || args[1].nil?
+              puts args[0].to_s
+            else
+              type = args[2] || 'kv'
+              tags = args[3] ? "##{args[3]}" : nil
+              puts [args[0..1].join(':'), type, tags].compact.join('|')
+            end
+          end
+        end
+
+        class Influxdb < Sensu::Plugin::CLI
+          # Outputs metrics using the InfluxDB line protocol format
+          #
+          # @param args [Array<String, Int>] list of arguments
+          # @note the argument order should be:
+          #   `measurement_name`: Mandatory, name for the InfluxDB measurement,
+          #   `fields`: Mandatory, either an integer or a comma separated key=value string `field1=value1,field2=value2`
+          #   `tags`: Optional, a comma separated key=value string `tag1=value1,tag2=value2`
+          #   `timestamp`: Optional, unix timestamp, defaults to current time
+          # @return [String] formated metric data
+          def output(*args)
+            return if args.empty?
+            if args[0].is_a?(Exception) || args[1].nil?
+              puts args[0].to_s
+            else
+              fields = if args[1].is_a?(Integer)
+                         "value=#{args[1]}"
+                       else
+                         args[1]
+                       end
+              measurement = [args[0], args[2]].compact.join(',')
+              ts = args[3] || Time.now.to_i
+              puts [measurement, fields, ts].join(' ')
             end
           end
         end

--- a/test/external/dogstatsd-output
+++ b/test/external/dogstatsd-output
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require 'sensu-plugin/metric/cli'
+
+class TestMetric < Sensu::Plugin::Metric::CLI::Dogstatsd
+  def run
+    output 'a', 1, 'ms'
+    output 'b.c.d', 15, 'g', 'env:test,dummy'
+    ok
+  end
+end

--- a/test/external/influxdb-output
+++ b/test/external/influxdb-output
@@ -6,7 +6,7 @@ class TestMetric < Sensu::Plugin::Metric::CLI::Influxdb
   def run
     output 'sensu', 'baz=42', 'env=prod,location=us-midwest'
     output 'sensu', 50, 'env=prod,location=us-midwest'
-    output 'sensu', 'foo=100', 'env=prod,location=us-midwest'
+    output 'sensu', 'foo=100', 'env=prod,location=us-midwest', Time.now.to_i
     ok
   end
 end

--- a/test/external/influxdb-output
+++ b/test/external/influxdb-output
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+require 'sensu-plugin/metric/cli'
+
+class TestMetric < Sensu::Plugin::Metric::CLI::Influxdb
+  def run
+    output 'sensu', 'baz=42', 'env=prod,location=us-midwest'
+    output 'sensu', 50, 'env=prod,location=us-midwest'
+    output 'sensu', 'foo=100', 'env=prod,location=us-midwest'
+    ok
+  end
+end

--- a/test/external/multi-output
+++ b/test/external/multi-output
@@ -5,7 +5,7 @@ require 'sensu-plugin/metric/cli'
 class TestMetric < Sensu::Plugin::Metric::CLI::Graphite
   def run
     output 'a', 1
-    output 'b', 2
+    output 'b', 2, Time.now.to_i
     ok
   end
 end

--- a/test/external_metric_test.rb
+++ b/test/external_metric_test.rb
@@ -43,3 +43,38 @@ class TestStatsdMetricExternal < MiniTest::Test
     end
   end
 end
+
+class TestDogstatsdMetricExternal < MiniTest::Test
+  include SensuPluginTestHelper
+
+  def setup
+    set_script 'external/dogstatsd-output'
+  end
+
+  def test_dogstatsd
+    lines = run_script.split("\n")
+    assert lines.size == 2
+    assert lines.last.split('|').last.split(',').size == 2
+    lines.each do |line|
+      assert line.split('|').size >= 2
+      assert line.split('|').first.split(':').size == 2
+    end
+  end
+end
+
+class TestInfluxdbMetricExternal < MiniTest::Test
+  include SensuPluginTestHelper
+
+  def setup
+    set_script 'external/influxdb-output'
+  end
+
+  def test_dogstatsd
+    lines = run_script.split("\n")
+    assert lines.size == 3
+    lines.each do |line|
+      assert line.split(' ').size == 3
+      assert line.split(' ').first.split(',').size == 3
+    end
+  end
+end

--- a/test/external_metric_test.rb
+++ b/test/external_metric_test.rb
@@ -23,7 +23,10 @@ class TestGraphiteMetricExternal < MiniTest::Test
 
   def test_multi
     lines = run_script.split("\n")
-    assert lines.size == 2 && lines.all? { |line| line.split("\s").size == 3 }
+    assert lines.size == 2
+    lines.each do |line|
+      assert line.split("\s").size == 3
+    end
   end
 end
 
@@ -73,8 +76,8 @@ class TestInfluxdbMetricExternal < MiniTest::Test
     lines = run_script.split("\n")
     assert lines.size == 3
     lines.each do |line|
-      assert line.split(' ').size == 3
-      assert line.split(' ').first.split(',').size == 3
+      assert line.split("\s").size == 3
+      assert line.split("\s").first.split(',').size == 3
     end
   end
 end


### PR DESCRIPTION
This adds new output formats for InfluxDB and DogStatsD

## Description
Adds two new subclasses, one for InfluxDB and another one for DogStatsD.

## Motivation and Context
I'm using InfluxDB and I wanted to have a way of creating plugins that natively supported, I also believe that Graphite's lack of support for tags is limiting so, I added two new formats that support tags.

## How Has This Been Tested?
Created new tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
