### PR TITLE
adding link to blog post about event filter deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ IMPORTANT! This release includes the following potentially breaking changes:
 - Plugins now exit with status `3` (unknown) when encountering an
   exception or being run with bad arguments.
 - Removed support for Ruby 1.9 and earlier.
-- Deprecated filtering methods in this library are now disabled by default.
+- Deprecated filtering methods in this library are now disabled by default. For more information read this [blog post](https://blog.sensuapp.org/deprecating-event-filtering-in-sensu-plugin-b60c7c500be3)
 
 ## [v1.4.5] - 2017-03-07
 ### Added


### PR DESCRIPTION

## Description
adding link to blog post about event filter deprecation

## Motivation and Context
While in 1.4 it was mentioned the real breaking change happened at 2.0 and it makes it more likely that people will catch the breaking change before upgrading. https://github.com/sensu-plugins/sensu-plugins-docker/pull/57#discussion_r138260729

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non code change (documentation, changelog, tests, etc)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
