### PR TITLE
add multiple metrics output format support #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added subclass for Generic metrics output to support multiple metrics output formats (@bergerx)
+
+### Changed
+- updated metrics class inheritance hierarchy (@bergerx)
 
 ## [2.3.0] - 2017-08-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For a metric, you can subclass one of the following:
  * `Sensu::Plugin::Metric::CLI::Statsd`
  * `Sensu::Plugin::Metric::CLI::Dogstatsd`
  * `Sensu::Plugin::Metric::CLI::Influxdb`
+ * `Sensu::Plugin::Metric::CLI::Generic`
 
 Instead of outputting a Nagios-style line of text, these classes will output
 differently formated messages depending on the class you chose.
@@ -116,17 +117,33 @@ class MyInfluxdbMetric < Sensu::Plugin::Metric::CLI::Influxdb
 end
 ```
 
-JSON output takes one argument (the object), and adds a 'timestamp' key
-if missing. Graphite output takes two arguments, the metric path and the
-value, and optionally the timestamp as a third argument. `Time.now.to_i`
-is used for the timestamp if it is not specified. Statsd output takes three
-arguments, the metric path, the value and the type. Dogstatsd output takes
-three arguments, the metric path, the value, the type and optionally a comma
-separated list of tags, use colons for key/value tags, i.e. `env:prod`.
-Influxdb output takes two arguments, the measurement name and the value or a
-comma separated list of values, use `=` for field/value, i.e. `value=42`,
-optionally you can also pass a comma separated list of tags and a timestamp
-`Time.now.to_i` is used for the timestamp if it is not specified.
+```ruby
+require 'sensu-plugin/metric/cli'
+
+class MyInfluxdbMetric < Sensu::Plugin::Metric::CLI::Generic
+
+  def run
+    ok metric_name: 'metric.name', value: 0
+  end
+
+end
+```
+
+**JSON output** takes one argument (the object), and adds a 'timestamp'
+key if missing. **Graphite output** takes two arguments, the metric path
+and the value, and optionally the timestamp as a third argument.
+`Time.now.to_i` is used for the timestamp if it is not
+specified. **Statsd output** takes three arguments, the metric path, the
+value and the type.  **Dogstatsd output** takes three arguments, the
+metric path, the value, the type and optionally a comma separated list
+of tags, use colons for key/value tags, i.e.  `env:prod`.  **Influxdb
+output** takes two arguments, the measurement name and the value or a
+comma separated list of values, use `=` for field/value,
+i.e. `value=42`, optionally you can also pass a comma separated list of
+tags and a timestamp `Time.now.to_i` is used for the timestamp if it is
+not specified.  **Generic output** takes a dictionary and can provide
+requested output format with same logic. And inherited class will have a
+`--metric_format` option to switch between different output formats.
 
 Exit codes do not affect metric output, but they can still be used by
 your handlers.

--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -4,103 +4,195 @@ require 'json'
 module Sensu
   module Plugin
     class Metric
-      class CLI
-        class JSON < Sensu::Plugin::CLI
-          def output(obj = nil)
-            if obj.is_a?(String) || obj.is_a?(Exception)
-              puts obj.to_s
-            elsif obj.is_a?(Hash)
-              obj['timestamp'] ||= Time.now.to_i
-              puts ::JSON.generate(obj)
-            end
+      class CLI < Sensu::Plugin::CLI
+        # Outputs metrics using raw json format
+        #
+        # @param obj [Hash] there is no strict expectation from the provided object
+        # @return [String] formated metric data
+        def to_json(obj = nil)
+          if obj.is_a?(String) || obj.is_a?(Exception)
+            puts obj.to_s
+          elsif obj.is_a?(Hash)
+            obj['timestamp'] ||= Time.now.to_i
+            puts ::JSON.generate(obj)
           end
         end
 
-        class Graphite < Sensu::Plugin::CLI
-          # Outputs metrics using the Statsd datagram format
-          #
-          # @param args [Array<String, Int>] list of arguments
-          # @note the argument order should be:
-          #   `metric_path`: Mandatory, name for the metric,
-          #   `value`: Mandatory, metric value
-          #   `timestamp`: Optional, unix timestamp, defaults to current time
-          # @return [String] formated metric data
+        # Outputs metrics using the Statsd datagram format
+        #
+        # @param args [Array<String, Int>] list of arguments
+        # @note the argument order should be:
+        #   `metric_path`: Mandatory, name for the metric,
+        #   `value`: Mandatory, metric value
+        #   `timestamp`: Optional, unix timestamp, defaults to current time
+        # @return [String] formated metric data
+        def to_graphite(*args)
+          return if args.join.empty?
+          if args[0].is_a?(Exception) || args[1].nil?
+            puts args[0].to_s
+          else
+            args[2] ||= Time.now.to_i
+            puts args[0..2].join("\s")
+          end
+        end
+
+        # Outputs metrics using the Statsd datagram format
+        #
+        # @param args [Array<String, Int>] list of arguments
+        # @note the argument order should be:
+        #   `metric_name`: Mandatory, name for the metric,
+        #   `value`: Mandatory, metric value
+        #   `type`: Optional, metric type- `c` for counter, `g` for gauge, `ms` for timer, `s` for set
+        # @return [String] formated metric data
+        def to_statsd(*args)
+          return if args.join.empty?
+          if args[0].is_a?(Exception) || args[1].nil?
+            puts args[0].to_s
+          else
+            type = args[2] || 'kv'
+            puts [args[0..1].join(':'), type].join('|')
+          end
+        end
+
+        # Outputs metrics using the DogStatsd datagram format
+        #
+        # @param args [Array<String, Int>] list of arguments
+        # @note the argument order should be:
+        #   `metric_name`: Mandatory, name for the metric,
+        #   `value`: Mandatory, metric value
+        #   `type`: Optional, metric type- `c` for counter, `g` for gauge, `ms` for timer, `h` for histogram, `s` for set
+        #   `tags`: Optional, a comma separated key:value string `tag1:value1,tag2:value2`
+        # @return [String] formated metric data
+        def to_dogstatsd(*args)
+          return if args.join.empty?
+          if args[0].is_a?(Exception) || args[1].nil?
+            puts args[0].to_s
+          else
+            type = args[2] || 'kv'
+            tags = args[3] ? "##{args[3]}" : nil
+            puts [args[0..1].join(':'), type, tags].compact.join('|')
+          end
+        end
+
+        # Outputs metrics using the InfluxDB line protocol format
+        #
+        # @param args [Array<String, Int>] list of arguments
+        # @note the argument order should be:
+        #   `measurement_name`: Mandatory, name for the InfluxDB measurement,
+        #   `fields`: Mandatory, either an integer or a comma separated key=value string `field1=value1,field2=value2`
+        #   `tags`: Optional, a comma separated key=value string `tag1=value1,tag2=value2`
+        #   `timestamp`: Optional, unix timestamp, defaults to current time
+        # @return [String] formated metric data
+        def to_influxdb(*args)
+          return if args.join.empty?
+          if args[0].is_a?(Exception) || args[1].nil?
+            puts args[0].to_s
+          else
+            fields = if args[1].is_a?(Integer)
+                       "value=#{args[1]}"
+                     else
+                       args[1]
+                     end
+            measurement = [args[0], args[2]].compact.join(',')
+            ts = args[3] || Time.now.to_i
+            puts [measurement, fields, ts].join(' ')
+          end
+        end
+
+        class JSON < Sensu::Plugin::Metric::CLI
           def output(*args)
-            return if args.empty?
-            if args[0].is_a?(Exception) || args[1].nil?
-              puts args[0].to_s
-            else
-              args[2] ||= Time.now.to_i
-              puts args[0..2].join("\s")
-            end
+            to_json(*args)
           end
         end
 
-        class Statsd < Sensu::Plugin::CLI
-          # Outputs metrics using the Statsd datagram format
-          #
-          # @param args [Array<String, Int>] list of arguments
-          # @note the argument order should be:
-          #   `metric_name`: Mandatory, name for the metric,
-          #   `value`: Mandatory, metric value
-          #   `type`: Optional, metric type- `c` for counter, `g` for gauge, `ms` for timer, `s` for set
-          # @return [String] formated metric data
+        class Graphite < Sensu::Plugin::Metric::CLI
           def output(*args)
-            return if args.empty?
-            if args[0].is_a?(Exception) || args[1].nil?
-              puts args[0].to_s
-            else
-              type = args[2] || 'kv'
-              puts [args[0..1].join(':'), type].join('|')
-            end
+            to_graphite(*args)
           end
         end
 
-        class Dogstatsd < Sensu::Plugin::CLI
-          # Outputs metrics using the DogStatsd datagram format
+        class Statsd < Sensu::Plugin::Metric::CLI
+          def output(*args)
+            to_statsd(*args)
+          end
+        end
+
+        class Dogstatsd < Sensu::Plugin::Metric::CLI
+          def output(*args)
+            to_dogstatsd(*args)
+          end
+        end
+
+        class Influxdb < Sensu::Plugin::Metric::CLI
+          def output(*args)
+            to_influxdb(*args)
+          end
+        end
+
+        class Generic < Sensu::Plugin::Metric::CLI
+          option :metric_format,
+                 long: '--metric_format METRIC_FORMAT',
+                 in: ['json', 'graphite', 'statsd', 'dogstatsd', 'influxdb'],
+                 default: 'graphite'
+
+          # Outputs metrics using different metric formats
           #
-          # @param args [Array<String, Int>] list of arguments
-          # @note the argument order should be:
+          # @param metric [Hash] the metric hash with keys below
+          # @note the metric could have these fields:
           #   `metric_name`: Mandatory, name for the metric,
           #   `value`: Mandatory, metric value
           #   `type`: Optional, metric type- `c` for counter, `g` for gauge, `ms` for timer, `h` for histogram, `s` for set
-          #   `tags`: Optional, a comma separated key:value string `tag1:value1,tag2:value2`
-          # @return [String] formated metric data
-          def output(*args)
-            return if args.empty?
-            if args[0].is_a?(Exception) || args[1].nil?
-              puts args[0].to_s
-            else
-              type = args[2] || 'kv'
-              tags = args[3] ? "##{args[3]}" : nil
-              puts [args[0..1].join(':'), type, tags].compact.join('|')
-            end
-          end
-        end
+          #   `tags`: Optional, a Hash that includes all tags
+          #   `timestamp`: Optional, unix timestamp, eventually defaults to output's timestamp handling
+          #   `graphite_metric_path`: Optional, `metric_name` will be used if not provided.
+          #   `statsd_metric_name`: Optional, `metric_name` will be used if not provided.
+          #   `statsd_type`: Optional.
+          #   `dogstatsd_metric_name`: Optional, `statsd_metric_name` or `metric_name` will be used if not provided.
+          #   `dogstatsd_type`: Optional, `statsd_type` will be used if not provided.
+          #   `influxdb_measurement`: Optional, class name will be used if not provided.
+          #   `influxdb_field_key`: Optional, the `metric_name` will be used if not provided.
+          # @return [String] formated metric data based on metric_format configuration.
+          def output(metric = {})
+            return if metric.nil? ||
+                      metric.empty? ||
+                      metric[:value].nil?
 
-        class Influxdb < Sensu::Plugin::CLI
-          # Outputs metrics using the InfluxDB line protocol format
-          #
-          # @param args [Array<String, Int>] list of arguments
-          # @note the argument order should be:
-          #   `measurement_name`: Mandatory, name for the InfluxDB measurement,
-          #   `fields`: Mandatory, either an integer or a comma separated key=value string `field1=value1,field2=value2`
-          #   `tags`: Optional, a comma separated key=value string `tag1=value1,tag2=value2`
-          #   `timestamp`: Optional, unix timestamp, defaults to current time
-          # @return [String] formated metric data
-          def output(*args)
-            return if args.empty?
-            if args[0].is_a?(Exception) || args[1].nil?
-              puts args[0].to_s
-            else
-              fields = if args[1].is_a?(Integer)
-                         "value=#{args[1]}"
-                       else
-                         args[1]
-                       end
-              measurement = [args[0], args[2]].compact.join(',')
-              ts = args[3] || Time.now.to_i
-              puts [measurement, fields, ts].join(' ')
+            tags = metric[:tags] || []
+
+            case config[:metric_format]
+            when 'json'
+              return if metric[:value].nil?
+              json_obj = metric[:json_obj] || {
+                metric_name: metric[:metric_name],
+                value: metric[:value],
+                tags: tags
+              }
+              to_json json_obj
+            when 'graphite'
+              graphite_metric_path = metric[:graphite_metric_path] ||
+                                     metric[:metric_name]
+              to_graphite graphite_metric_path, metric[:value], metric[:timestamp]
+            when 'statsd'
+              statsd_metric_name = metric[:statsd_metric_name] ||
+                                   metric[:metric_name]
+              to_statsd statsd_metric_name, metric[:value], metric[:statsd_type]
+            when 'dogstatsd'
+              dogstatsd_metric_name = metric[:dogstatsd_metric_name] ||
+                                      metric[:statsd_metric_name] ||
+                                      metric[:metric_name]
+              dogstatsd_type = metric[:dogstatsd_type] || metric[:statsd_type]
+              dogstatsd_tags = tags.map { |k, v| "#{k}:#{v}" }.join(',')
+              to_dogstatsd dogstatsd_metric_name, metric[:value],
+                           dogstatsd_type, dogstatsd_tags
+            when 'influxdb'
+              influxdb_measurement = metric[:influxdb_measurement] ||
+                                     self.class.name
+              influxdb_field_key = metric[:influxdb_field_key] ||
+                                   metric[:metric_name]
+              influxdb_field = "#{influxdb_field_key}=#{metric[:value]}"
+              influxdb_tags = tags.map { |k, v| "#{k}=#{v}" }.join(',')
+              to_influxdb influxdb_measurement, influxdb_field,
+                          influxdb_tags, metric[:timestamp]
             end
           end
         end

--- a/test/external/generic-metrics
+++ b/test/external/generic-metrics
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'sensu-plugin/metric/cli'
+
+class GenericTestMetric < Sensu::Plugin::Metric::CLI::Generic
+  def run
+    output metric_name: 'metric.name', value: 0
+    output metric_name: 'metric.name', value: 1,
+           tags: { env: 'prod', location: 'us-midwest' }
+    output metric_name: 'metric.name', value: 2,
+           graphite_metric_path: 'graphite.metric.path'
+    output metric_name: 'metric.name', value: 3,
+           statsd_metric_name: 'statsd.metric.name',
+           statsd_type: 's'
+    output metric_name: 'metric.name', value: 4,
+           dogstatsd_metric_name: 'statsd.metric.name',
+           dogstatsd_type: 'm'
+    output metric_name: 'metric.name', value: 5,
+           statsd_metric_name: 'statsd.metric.name',
+           dogstatsd_metric_name: 'dogstatsd.metric.name'
+    output metric_name: 'metric.name', value: 6,
+           influxdb_measurement: 'influxdb.measurement'
+    output metric_name: 'metric.name', value: 7,
+           influxdb_field_key: 'influxdb.field'
+    ok
+  end
+end

--- a/test/external_metric_test.rb
+++ b/test/external_metric_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'English'
+require 'json'
 
 class TestMetricExternal < MiniTest::Test
   include SensuPluginTestHelper
@@ -79,5 +80,56 @@ class TestInfluxdbMetricExternal < MiniTest::Test
       assert line.split("\s").size == 3
       assert line.split("\s").first.split(',').size == 3
     end
+  end
+end
+
+class TestGenericMetricsExternal < MiniTest::Test
+  include SensuPluginTestHelper
+
+  def test_json
+    set_script 'external/generic-metrics --metric_format json'
+    lines = run_script.split("\n")
+    assert lines.size == 8
+    lines.each { |line| assert line.include? 'metric_name' }
+  end
+
+  def test_graphite
+    set_script 'external/generic-metrics --metric_format graphite'
+    lines = run_script.split("\n")
+    assert lines.size == 8
+    assert lines[1].include? 'metric.name 1'
+    assert lines[2].include? 'graphite.metric.path 2'
+  end
+
+  def test_statsd
+    set_script 'external/generic-metrics --metric_format statsd'
+    lines = run_script.split("\n")
+    assert lines.size == 8
+    assert lines[2].include? 'metric.name:2|kv'
+    assert lines[3].include? 'statsd.metric.name:3|s'
+    assert lines[4].include? 'metric.name:4|kv'
+    assert lines[5].include? 'statsd.metric.name:5|kv'
+  end
+
+  def test_dogstatsd
+    set_script 'external/generic-metrics --metric_format dogstatsd'
+    lines = run_script.split("\n")
+    assert lines.size == 8
+    assert lines[1].include? 'metric.name:1|kv|#env:prod,location:us-midwest'
+    assert lines[2].include? 'metric.name:2|kv|#'
+    assert lines[3].include? 'statsd.metric.name:3|s|#'
+    assert lines[4].include? 'statsd.metric.name:4|m|#'
+    assert lines[5].include? 'dogstatsd.metric.name:5|kv|#'
+  end
+
+  def test_influxdb
+    set_script 'external/generic-metrics --metric_format influxdb'
+    lines = run_script.split("\n")
+    assert lines.size == 8
+    assert lines[0].include? 'GenericTestMetric, metric.name=0 '
+    assert lines[1].include? 'GenericTestMetric,env=prod,location=us-midwest metric.name=1 '
+    assert lines[2].include? 'GenericTestMetric, metric.name=2 '
+    assert lines[6].include? 'influxdb.measurement, metric.name=6 '
+    assert lines[7].include? 'GenericTestMetric, influxdb.field=7 '
   end
 end


### PR DESCRIPTION
This will add support for multiple metric output formats within the same class.

## Description
This changes moves the different output formats into a base metrics cli class and let implementers to choose the output format on runtime.

## Motivation and Context
We have been struggling to use various sensu metrics plugin scripts since most of the existing plugins are generating metrics in graphite format and this format is not easy to map to other metric storage architectures with tags that can't be known ahead of time. So we've been either forced to (re)implement copies of the graphite metrics collector scripts in our choice of metrics storage or maintain mappings for grafana metric path to other metrics storage option. E.g. We've been using influxdb templates to map grafana metric path to influxdb measurement, tags, fields and trying to maintain the mapping templates is not optimal for long term operational goals.

Expectation is to let the graphite specific plugins to start using the generic metrics class and start supporting other metric formats without having to copy the metric collection logic. The `output` function calls in metric collection scripts needs to decorated with a better metadata for this change.

This issue has been previously discussed in #37, and this is just an initial implementation for the idea there. And one of the main blocking issues (chef/mixlib-cli#13) seems to be solved after that ticket is open. 

## How Has This Been Tested?
Here are the test results, I also added some tests to cpover the new feature:

```shell
sensu-plugin: (generic-metrics u=) $ bundle exec rake
Running RuboCop...
Inspecting 34 files
..................................

34 files inspected, no offenses detected
Run options: --seed 60796

# Running:

......................................................

Finished in 8.552982s, 6.3136 runs/s, 16.6024 assertions/s.

54 runs, 142 assertions, 0 failures, 0 errors, 0 skips
sensu-plugin: (generic-metrics u=) $ bundle exec test/external/generic-metrics  --metric_format graphite
metric.name 0 1517963264
metric.name 1 1517963264
graphite.metric.path 2 1517963264
metric.name 3 1517963264
metric.name 4 1517963264
metric.name 5 1517963264
metric.name 6 1517963264
metric.name 7 1517963264
sensu-plugin: (generic-metrics u=) $ bundle exec test/external/generic-metrics  --metric_format dogstatsd
metric.name:0|kv|#
metric.name:1|kv|#env:prod,location:us-midwest
metric.name:2|kv|#
statsd.metric.name:3|s|#
statsd.metric.name:4|m|#
dogstatsd.metric.name:5|kv|#
metric.name:6|kv|#
metric.name:7|kv|#
sensu-plugin: (generic-metrics u=) $ bundle exec test/external/generic-metrics  --metric_format influxdb
GenericTestMetric, metric.name=0 1517963271
GenericTestMetric,env=prod,location=us-midwest metric.name=1 1517963271
GenericTestMetric, metric.name=2 1517963271
GenericTestMetric, metric.name=3 1517963271
GenericTestMetric, metric.name=4 1517963271
GenericTestMetric, metric.name=5 1517963271
influxdb.measurement, metric.name=6 1517963271
GenericTestMetric, influxdb.field=7 1517963271
sensu-plugin: (generic-metrics u=) $ 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
