### PR TITLE
Support Handler Sensu Enterprise API HTTPS requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added Handler Sensu API HTTPS support through API configuration (e.g. `{"api": {"ssl": {}}`.
 
 ## [2.4.0] - 2018-02-08
 ### Added

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -99,6 +99,14 @@ module Sensu
       exit 0
     end
 
+    # Override API settings (for testing purposes)
+    #
+    # @param api_settings [Hash]
+    # @return [Hash]
+    def api_settings=(api_settings)
+      @api_settings = api_settings
+    end
+
     # Return a hash of API settings derived first from ENV['SENSU_API_URL'] if set,
     # then Sensu config `api` scope if configured, and finally falling back to
     # to ipv4 localhost address on default API port.

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'webmock'
 end

--- a/test/handle_api_request_test.rb
+++ b/test/handle_api_request_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'webmock/minitest'
+require 'sensu-handler'
+
+class TestHandleAPIRequest < MiniTest::Test
+  include SensuPluginTestHelper
+
+  Sensu::Handler.disable_autorun
+
+  def test_http_request
+    stub_request(:get, 'http://127.0.0.1:4567/foo').to_return(status: 200, body: '', headers: {})
+
+    handler = Sensu::Handler.new([])
+    response = handler.api_request(:get, '/foo')
+
+    assert_equal(response.code, '200')
+  end
+
+  def test_https_request
+    stub_request(:get, 'https://127.0.0.1:4567/foo').to_return(status: 200, body: '', headers: {})
+
+    handler = Sensu::Handler.new([])
+    handler.api_settings = handler.api_settings.merge('ssl' => {})
+
+    response = handler.api_request(:get, '/foo')
+
+    assert_equal(response.code, '200')
+  end
+end


### PR DESCRIPTION
This pull request adds support for Handler Sensu API HTTPS requests, adding support for Sensu API SSL configuration, e.g.`{"api": {"ssl": {}}` (Sensu Enterprise uses this).

Added webmock testing dependency and added Handler API request tests.