### PR TITLE
add paginated_get utils method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added utils method `paginated_get` for iteratively retrieving API responses (@cwjohnston).
 
 ## [2.5.0] - 2018-04-03
 ### Added

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -99,57 +99,6 @@ module Sensu
       exit 0
     end
 
-    # Override API settings (for testing purposes)
-    #
-    # @param api_settings [Hash]
-    # @return [Hash]
-    def api_settings=(api_settings)
-      @api_settings = api_settings
-    end
-
-    # Return a hash of API settings derived first from ENV['SENSU_API_URL'] if set,
-    # then Sensu config `api` scope if configured, and finally falling back to
-    # to ipv4 localhost address on default API port.
-    #
-    # @return [Hash]
-    def api_settings
-      return @api_settings if @api_settings
-      if ENV['SENSU_API_URL']
-        uri = URI(ENV['SENSU_API_URL'])
-        ssl = uri.scheme == 'https' ? {} : nil
-        @api_settings = {
-          'ssl' => ssl,
-          'host' => uri.host,
-          'port' => uri.port,
-          'user' => uri.user,
-          'password' => uri.password
-        }
-      else
-        @api_settings = settings['api'] || {}
-        @api_settings['host'] ||= '127.0.0.1'
-        @api_settings['port'] ||= 4567
-      end
-      @api_settings
-    end
-
-    def api_request(method, path, &_blk)
-      if api_settings.nil?
-        raise 'api.json settings not found.'
-      end
-      use_ssl = api_settings['ssl'].is_a?(Hash) ||
-                api_settings['host'].start_with?('https')
-      hostname = api_settings['host'].gsub(/https?:\/\//, '')
-      req = net_http_req_class(method).new(path)
-      if api_settings['user'] && api_settings['password']
-        req.basic_auth(api_settings['user'], api_settings['password'])
-      end
-      yield(req) if block_given?
-      res = Net::HTTP.start(hostname, api_settings['port'], use_ssl: use_ssl) do |http|
-        http.request(req)
-      end
-      res
-    end
-
     def filter_disabled
       bail 'alert disabled' if @event['check']['alert'] == false
     end

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -46,13 +46,13 @@ module Sensu
         end
       end
 
-
       # Use API query parameters to paginate HTTP GET requests,
       # iterating over the results until an empty set is returned.
       #
       # @param path [String]
       # @param options [Hash]
       # @return [Array]
+
       def paginated_get(path, options = {})
         limit = options.fetch('limit', 500)
         offset = 0

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -2,7 +2,7 @@ require 'json'
 
 module Sensu
   module Plugin
-    module Utils
+    module Utils # rubocop:disable Metrics/ModuleLength
       def config_files
         if ENV['SENSU_LOADED_TEMPFILE'] && File.file?(ENV['SENSU_LOADED_TEMPFILE'])
           IO.read(ENV['SENSU_LOADED_TEMPFILE']).split(':')
@@ -44,6 +44,57 @@ module Sensu
         when 'PUT'
           Net::HTTP::Put
         end
+      end
+
+      # Override API settings (for testing purposes)
+      #
+      # @param api_settings [Hash]
+      # @return [Hash]
+      def api_settings=(api_settings)
+        @api_settings = api_settings
+      end
+
+      # Return a hash of API settings derived first from ENV['SENSU_API_URL'] if set,
+      # then Sensu config `api` scope if configured, and finally falling back to
+      # to ipv4 localhost address on default API port.
+      #
+      # @return [Hash]
+      def api_settings
+        return @api_settings if @api_settings
+        if ENV['SENSU_API_URL']
+          uri = URI(ENV['SENSU_API_URL'])
+          ssl = uri.scheme == 'https' ? {} : nil
+          @api_settings = {
+            'ssl' => ssl,
+            'host' => uri.host,
+            'port' => uri.port,
+            'user' => uri.user,
+            'password' => uri.password
+          }
+        else
+          @api_settings = settings['api'] || {}
+          @api_settings['host'] ||= '127.0.0.1'
+          @api_settings['port'] ||= 4567
+        end
+        @api_settings
+      end
+
+      def api_request(method, path, &_blk)
+        if api_settings.nil?
+          raise 'api.json settings not found.'
+        end
+        use_ssl = api_settings['ssl'].is_a?(Hash) ||
+                  api_settings['host'].start_with?('https')
+        hostname = api_settings['host'].gsub(/https?:\/\//, '')
+        req = net_http_req_class(method).new(path)
+        if api_settings['user'] && api_settings['password']
+          req.basic_auth(api_settings['user'], api_settings['password'])
+        end
+        yield(req) if block_given?
+        res = Net::HTTP.start(hostname, api_settings['port'], use_ssl: use_ssl) do |http|
+          http.request(req)
+        end
+        res
       end
 
       # Use API query parameters to paginate HTTP GET requests,

--- a/test/handle_api_request_test.rb
+++ b/test/handle_api_request_test.rb
@@ -33,15 +33,18 @@ class TestHandleAPIRequest < MiniTest::Test
   end
 
   def test_http_paginated_get
-    stub_request(:get, 'http://127.0.0.1:4567/results?limit=50&offset=0')
+    stub_request(:get, 'http://127.0.0.1:4567/results?limit=1&offset=0')
       .to_return(status: 200, headers: {}, body: JSON.dump([sample_check_result]))
 
-    stub_request(:get, 'http://127.0.0.1:4567/results?limit=50&offset=50')
-      .to_return(status: 200, headers: {}, body: JSON.dump([]))
+    stub_request(:get, 'http://127.0.0.1:4567/results?limit=1&offset=1')
+      .to_return(status: 200, headers: {}, body: JSON.dump([sample_check_result]))
+
+    stub_request(:get, 'http://127.0.0.1:4567/results?limit=1&offset=2')
+      .to_return(status: 200, headers: {}, body: JSON.dump([])
 
     handler = Sensu::Handler.new([])
-    response = handler.paginated_get('/results', 'limit' => 50)
-    assert_equal(response, [sample_check_result])
+    response = handler.paginated_get('/results', 'limit' => 1)
+    assert_equal(response, JSON.dump([sample_check_result,sample_check_result])
   end
 
   def test_https_request

--- a/test/handle_api_request_test.rb
+++ b/test/handle_api_request_test.rb
@@ -7,6 +7,22 @@ class TestHandleAPIRequest < MiniTest::Test
 
   Sensu::Handler.disable_autorun
 
+  def sample_check_result
+    {
+      client: 'sensu',
+      check: {
+        handler: 'keepalive',
+        name: 'keepalive',
+        issued: 1_534_373_016,
+        executed: 1_534_373_016,
+        output: 'Keepalive sent from client 4 seconds ago',
+        status: 0,
+        type: 'standard',
+        history: [0]
+      }
+    }
+  end
+
   def test_http_request
     stub_request(:get, 'http://127.0.0.1:4567/foo').to_return(status: 200, body: '', headers: {})
 
@@ -14,6 +30,18 @@ class TestHandleAPIRequest < MiniTest::Test
     response = handler.api_request(:get, '/foo')
 
     assert_equal(response.code, '200')
+  end
+
+  def test_http_paginated_get
+    stub_request(:get, 'http://127.0.0.1:4567/results?limit=50&offset=0')
+      .to_return(status: 200, headers: {}, body: JSON.dump([sample_check_result]))
+
+    stub_request(:get, 'http://127.0.0.1:4567/results?limit=50&offset=50')
+      .to_return(status: 200, headers: {}, body: JSON.dump([]))
+
+    handler = Sensu::Handler.new([])
+    response = handler.paginated_get('/results', 'limit' => 50)
+    assert_equal(response, [sample_check_result])
   end
 
   def test_https_request

--- a/test/handle_api_request_test.rb
+++ b/test/handle_api_request_test.rb
@@ -44,7 +44,10 @@ class TestHandleAPIRequest < MiniTest::Test
 
     handler = Sensu::Handler.new([])
     response = handler.paginated_get('/results', 'limit' => 1)
-    assert_equal(response, JSON.dump([sample_check_result, sample_check_result]))
+
+    # we expect the combined results to be an array containing two instances of the sample check result
+    combined_results = JSON.parse("[ #{JSON.dump(sample_check_result)} , #{JSON.dump(sample_check_result)} ]")
+    assert_equal(response, combined_results)
   end
 
   def test_https_request

--- a/test/handle_api_request_test.rb
+++ b/test/handle_api_request_test.rb
@@ -40,11 +40,11 @@ class TestHandleAPIRequest < MiniTest::Test
       .to_return(status: 200, headers: {}, body: JSON.dump([sample_check_result]))
 
     stub_request(:get, 'http://127.0.0.1:4567/results?limit=1&offset=2')
-      .to_return(status: 200, headers: {}, body: JSON.dump([])
+      .to_return(status: 200, headers: {}, body: JSON.dump([]))
 
     handler = Sensu::Handler.new([])
     response = handler.paginated_get('/results', 'limit' => 1)
-    assert_equal(response, JSON.dump([sample_check_result,sample_check_result])
+    assert_equal(response, JSON.dump([sample_check_result, sample_check_result]))
   end
 
   def test_https_request


### PR DESCRIPTION
## Description

Adds a utility method implementing paginated HTTP GET for Sensu API requests.

## Motivation and Context

Users with a large number of clients, events and/or check results have reported timeouts and other errors when executing checks and handlers which request a complete data set from the Sensu API.

As of Sensu 1.4 the API supports pagination for HTTP GET on a number of endpoints.

## How Has This Been Tested?

Same code has been implemented in [an experimental branch of sensu-plugins-sensu](https://github.com/sensu-plugins/sensu-plugins-sensu/tree/feature/paginated_get), where pagination has been implemented in the [check-stale-results.rb](https://github.com/sensu-plugins/sensu-plugins-sensu/blob/feature/paginated_get/bin/check-stale-results.rb) and [handler-purge-stale-results.rb](https://github.com/sensu-plugins/sensu-plugins-sensu/blob/feature/paginated_get/bin/handler-purge-stale-results.rb) plugins.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

I've added this method to the Sensu::Plugin::Utils module, because I think this method should be available to both check and handler plugins. That said, the method does call the `api_request` method which is part of Sensu::Plugin::Handler. Not 100% sure if this works in practice.

Possibly out of scope for this change, but can `api_request` and related methods be made available to Sensu::Plugin::Check::CLI without a breaking change to the library?