### PR TITLE
Fix paginated_get backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix `paginated_get` for backward compatibility with Sensu API < 1.4 (@cwjohnston).
 
 ## [2.6.0] - 2018-08-28
 ### Added

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -115,7 +115,11 @@ module Sensu
             unknown("Non-OK response from API query: #{get_uri(query_path)}")
           end
           data = JSON.parse(response.body)
+          # when the data is empty, we have hit the end
           break if data.empty?
+          # If API lacks pagination support, it will
+          # return same data on subsequent iterations
+          break if results.any? { |r| r == data }
           results << data
           offset += limit
         end

--- a/test/handle_api_request_test.rb
+++ b/test/handle_api_request_test.rb
@@ -33,11 +33,17 @@ class TestHandleAPIRequest < MiniTest::Test
   end
 
   def test_http_paginated_get
+    result_two = sample_check_result.dup
+    result_two[:client] = 'haproxy01'
+    result_two[:name]   = 'check_haproxy'
+    result_two[:output] = 'haproxy is fubar'
+    result_two[:status] = 2
+
     stub_request(:get, 'http://127.0.0.1:4567/results?limit=1&offset=0')
       .to_return(status: 200, headers: {}, body: JSON.dump([sample_check_result]))
 
     stub_request(:get, 'http://127.0.0.1:4567/results?limit=1&offset=1')
-      .to_return(status: 200, headers: {}, body: JSON.dump([sample_check_result]))
+      .to_return(status: 200, headers: {}, body: JSON.dump([result_two]))
 
     stub_request(:get, 'http://127.0.0.1:4567/results?limit=1&offset=2')
       .to_return(status: 200, headers: {}, body: JSON.dump([]))
@@ -46,7 +52,7 @@ class TestHandleAPIRequest < MiniTest::Test
     response = handler.paginated_get('/results', 'limit' => 1)
 
     # we expect the combined results to be an array containing two instances of the sample check result
-    combined_results = JSON.parse("[ #{JSON.dump(sample_check_result)} , #{JSON.dump(sample_check_result)} ]")
+    combined_results = JSON.parse("[ #{JSON.dump(sample_check_result)} , #{JSON.dump(result_two)} ]")
     assert_equal(response, combined_results)
   end
 


### PR DESCRIPTION
## Description

Fixes incompatibility in `paginated_get` with Sensu API version 1.3 and earlier.

## Motivation and Context

Sensu 1.4 added support for pagination of API requests using query string parameters.

Sensu Plugin 2.6.0 added `paginated_get` method for paginating API requests. 

When querying Sensu API version 1.3 or earlier, the paginated_get implementation in sensu-plugin 2.6.0 will potentially block forever, falsely iterating over the same data set.

## How Has This Been Tested?

Tested against versions 1.3 and 1.4 of Sensu API

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats

None.