### PR TITLE
update lock for `mixlib-cli` to `~> 1.5` as 2.0 removes ruby < 2.5 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,3 @@
-
 MethodLength:
   Max: 200
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- locked `mixlib-cli` dep to `~> 1.5` as `2.0` removes ruby support for `< 2.5` (@majormoses)
+
 ## [3.0.0] - 2018-12-04
 ### Breaking Changes
 - renamed event mapping utility function `map_v2_event_into_v1` to match naming change to Sensu Go `map_go_event_into_ruby` (@jspaleta)

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~> 2.0'
 
   s.add_dependency 'json',       '< 3.0.0'
-  s.add_dependency 'mixlib-cli', '>= 1.5.0'
+  s.add_dependency 'mixlib-cli', '~> 1.5'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop', '~> 0.49.0'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue reported: https://sensucommunity.slack.com/archives/C3C1D874M/p1546782233015800 due to `mixlib-cli` version `2.0` dropping support for ruby `< 2.5`

Error this fixes:
```
...
[SENSU-INSTALL] installing Sensu gem 'sensu-plugins-cpu-checks'
ERROR:  Error installing sensu-plugins-cpu-checks:
       mixlib-cli requires Ruby version >= 2.5.
[SENSU-INSTALL] failed to install Sensu gem 'sensu-plugins-cpu-checks'
...
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
beyond existing automated tested I have not done anything special for it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
none, technically this affects multiple versions but its unlikely worth backporting the fix more than each major version.