### PR TITLE
drop ruby `< 2.3` as they are EOL and appease the cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.3
+
 MethodLength:
   Max: 200
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
   - 2.3.0
   - 2.4.1
+  - 2.5.3
 before_install:
   - gem update bundler
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking Changes
+- remove support for EOL ruby `< 2.3` as they are EOL (@majormoses)
+
+### Changed
+- appease the cops (@majormoses)
+
 ## [3.0.1] - 2018-01-07
 ### Fixed
 - locked `mixlib-cli` dep to `~> 1.5` as `2.0` removes ruby support for `< 2.5` (@majormoses)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'

--- a/bin/mutator-sensu-go-into-ruby.rb
+++ b/bin/mutator-sensu-go-into-ruby.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-mutator'
 

--- a/lib/sensu-handler.rb
+++ b/lib/sensu-handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'net/http'
 require 'timeout'
 require 'uri'

--- a/lib/sensu-mutator.rb
+++ b/lib/sensu-mutator.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Sensu-mutator
 # ===

--- a/lib/sensu-plugin.rb
+++ b/lib/sensu-plugin.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module Sensu
   module Plugin
-    VERSION = '3.0.1'.freeze
+    VERSION = '3.0.1'
     EXIT_CODES = {
       'OK'       => 0,
       'WARNING'  => 1,

--- a/lib/sensu-plugin/check/cli.rb
+++ b/lib/sensu-plugin/check/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'sensu-plugin/cli'
 
 module Sensu

--- a/lib/sensu-plugin/cli.rb
+++ b/lib/sensu-plugin/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'sensu-plugin'
 require 'mixlib/cli'
 require 'English'

--- a/lib/sensu-plugin/metric/cli.rb
+++ b/lib/sensu-plugin/metric/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'sensu-plugin/cli'
 require 'json'
 

--- a/lib/sensu-plugin/utils.rb
+++ b/lib/sensu-plugin/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module Sensu

--- a/sensu-plugin.gemspec
+++ b/sensu-plugin.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.dirname(__FILE__)) + '/lib/sensu-plugin'
 
 Gem::Specification.new do |s|

--- a/test/cast_bool_value_test.rb
+++ b/test/cast_bool_value_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'sensu-plugin/utils'
 

--- a/test/deep_merge_test.rb
+++ b/test/deep_merge_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'sensu-plugin/utils'
 

--- a/test/external/bad-require
+++ b/test/external/bad-require
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/check/cli'
 require 'timederp' # hopefully never exists..

--- a/test/external/check-options
+++ b/test/external/check-options
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/check/cli'
 

--- a/test/external/dogstatsd-output
+++ b/test/external/dogstatsd-output
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/metric/cli'
 

--- a/test/external/generic-metrics
+++ b/test/external/generic-metrics
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/metric/cli'
 

--- a/test/external/handle-argument
+++ b/test/external/handle-argument
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'sensu-handler'
 
 class Argument < Sensu::Handler

--- a/test/external/handle-filter
+++ b/test/external/handle-filter
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'sensu-handler'
 
 class Filter < Sensu::Handler

--- a/test/external/handle-go-to-ruby
+++ b/test/external/handle-go-to-ruby
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'sensu-handler'
 
 class Helpers < Sensu::Handler

--- a/test/external/handle-helpers
+++ b/test/external/handle-helpers
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'sensu-handler'
 
 class Helpers < Sensu::Handler

--- a/test/external/handle-nofilter
+++ b/test/external/handle-nofilter
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'sensu-handler'
 
 class NoFilter < Sensu::Handler
   def filter; end
 
   def handle
-    puts 'Event: ' + @event.inspect
+    puts "Event: #{@event.inspect}"
   end
 end

--- a/test/external/influxdb-output
+++ b/test/external/influxdb-output
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/metric/cli'
 

--- a/test/external/multi-output
+++ b/test/external/multi-output
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/metric/cli'
 

--- a/test/external/mutator-helpers
+++ b/test/external/mutator-helpers
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-mutator'
 

--- a/test/external/mutator-trivial
+++ b/test/external/mutator-trivial
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-mutator'
 

--- a/test/external/statsd-output
+++ b/test/external/statsd-output
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/metric/cli'
 

--- a/test/external/trivial-metric
+++ b/test/external/trivial-metric
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'sensu-plugin/metric/cli'
 

--- a/test/external_check_test.rb
+++ b/test/external_check_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'English'
 

--- a/test/external_handler_argument_test.rb
+++ b/test/external_handler_argument_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'English'
 require 'minitest/autorun'

--- a/test/external_handler_test.rb
+++ b/test/external_handler_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'English'
 require 'json'

--- a/test/external_metric_test.rb
+++ b/test/external_metric_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'English'
 require 'json'

--- a/test/handle_api_request_test.rb
+++ b/test/handle_api_request_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'sensu-handler'

--- a/test/handle_filter_test.rb
+++ b/test/handle_filter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'English'
 require 'tempfile'

--- a/test/handle_go_to_1_test.rb
+++ b/test/handle_go_to_1_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'English'
 

--- a/test/handle_helper_test.rb
+++ b/test/handle_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'English'
 

--- a/test/mutator_go_to_1_test.rb
+++ b/test/mutator_go_to_1_test.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'English'
 
 require 'test_helper'

--- a/test/mutator_test.rb
+++ b/test/mutator_test.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'English'
 
 require 'test_helper'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'minitest/autorun'
 


### PR DESCRIPTION
Signed-off-by: Ben Abrams <me@benabrams.it>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Drop EOL rubies, add new ruby to be tested, and appeased the cops.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #199 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
only through automated tests currently, I can look at testing this in my env at some point.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

## Known Caveats
drops support for ruby `< 2.3` as they are EOL.